### PR TITLE
Apply Grulla Comenta design system to the site

### DIFF
--- a/public/logo-crane.svg
+++ b/public/logo-crane.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 80" fill="none" role="img" aria-label="Grulla Comenta origami crane">
+  
+  <g fill="currentColor">
+    
+    <path d="M41 39 L31 5 L60 19 Z" opacity="0.55"></path>
+    
+    <path d="M41 39 L31 5 L40 24 Z" opacity="0.8"></path>
+    
+    <path d="M41 39 L78 23 L62 41 Z" opacity="0.62"></path>
+    
+    <path d="M41 39 L7 28 L23 42 Z" opacity="0.9"></path>
+    
+    <path d="M9 28 L1 33 L13 33 Z" opacity="1"></path>
+    
+    <path d="M41 39 L23 42 L38 63 Z" opacity="1"></path>
+    
+    <path d="M41 39 L38 63 L53 55 Z" opacity="0.72"></path>
+  </g>
+</svg>

--- a/src/app/[locale]/anime-manga/page.tsx
+++ b/src/app/[locale]/anime-manga/page.tsx
@@ -74,46 +74,34 @@ export default function AnimeMangaPage() {
   if (loading) {
     return (
       <div className="flex justify-center items-center h-64">
-        <div className="text-gray-300">{t('loadingReviews')}</div>
+        <div className="text-ink-600">{t('loadingReviews')}</div>
       </div>
     );
   }
+
+  const filterBtn = (filter: string) =>
+    `px-4 py-2 text-sm font-ui font-bold rounded-pill transition-colors ${
+      activeFilter === filter
+        ? 'bg-persimmon-500 text-[#FFF8F0] shadow-sm'
+        : 'text-ink-700 bg-paper-200 hover:bg-paper-300'
+    }`;
+
   return (
     <div className="space-y-8">
       <div>
-        <h1 className="text-3xl font-bold text-white">{t('animeMangaTitle')}</h1>
-        <p className="mt-2 text-gray-300">{t('animeMangaDescription')}</p>
+        <span className="gc-kicker block mb-2">Anime &amp; Manga</span>
+        <h1 className="font-display text-3xl font-bold text-ink-900">{t('animeMangaTitle')}</h1>
+        <p className="mt-2 font-body text-ink-600">{t('animeMangaDescription')}</p>
       </div>
-      
-      <div className="flex space-x-4">
-        <button 
-          onClick={() => handleFilterChange('all')}
-          className={`px-4 py-2 text-sm font-medium rounded-md transition-colors ${
-            activeFilter === 'all' 
-              ? 'bg-blue-600 text-white' 
-              : 'text-gray-700 bg-gray-100 hover:bg-gray-200'
-          }`}
-        >
+
+      <div className="flex flex-wrap gap-3">
+        <button onClick={() => handleFilterChange('all')} className={filterBtn('all')}>
           {t('filterAll')}
         </button>
-        <button 
-          onClick={() => handleFilterChange('anime')}
-          className={`px-4 py-2 text-sm font-medium rounded-md transition-colors ${
-            activeFilter === 'anime' 
-              ? 'bg-blue-600 text-white' 
-              : 'text-gray-700 bg-gray-100 hover:bg-gray-200'
-          }`}
-        >
+        <button onClick={() => handleFilterChange('anime')} className={filterBtn('anime')}>
           {t('filterAnime')}
         </button>
-        <button 
-          onClick={() => handleFilterChange('manga')}
-          className={`px-4 py-2 text-sm font-medium rounded-md transition-colors ${
-            activeFilter === 'manga' 
-              ? 'bg-blue-600 text-white' 
-              : 'text-gray-700 bg-gray-100 hover:bg-gray-200'
-          }`}
-        >
+        <button onClick={() => handleFilterChange('manga')} className={filterBtn('manga')}>
           {t('filterManga')}
         </button>
       </div>
@@ -121,7 +109,7 @@ export default function AnimeMangaPage() {
       {filteredReviews.length > 0 ? (
         <ReviewGrid reviews={filteredReviews} />
       ) : (
-        <div className="text-center text-gray-400 py-8">
+        <div className="text-center text-ink-500 py-8">
           {activeFilter === 'all' 
             ? t('noReviewsGeneral')
             : t('noReviewsAvailable', { category: activeFilter })

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from 'react';
 import Link from 'next/link';
 import { useTranslations, useLocale } from 'next-intl';
 import ReviewGrid from '@/components/ReviewGrid';
+import { CraneMark } from '@/components/Crane';
 
 interface Review {
   id: string;
@@ -34,14 +35,14 @@ function ChevronRight() {
 
 function SkeletonGrid() {
   return (
-    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-5 gap-6">
-      {Array.from({ length: 5 }).map((_, i) => (
-        <div key={i} className="bg-gray-800/50 rounded-lg overflow-hidden animate-pulse">
-          <div className="aspect-video bg-gray-700/60" />
-          <div className="p-4 space-y-2.5">
-            <div className="h-4 bg-gray-700/60 rounded w-5/6" />
-            <div className="h-3 bg-gray-700/60 rounded w-2/3" />
-            <div className="h-3 bg-gray-700/60 rounded w-1/3" />
+    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
+      {Array.from({ length: 4 }).map((_, i) => (
+        <div key={i} className="bg-paper-50 border border-border rounded-lg overflow-hidden animate-pulse">
+          <div className="aspect-video bg-paper-300/60" />
+          <div className="p-5 space-y-3">
+            <div className="h-3 bg-paper-300/70 rounded-pill w-1/3" />
+            <div className="h-5 bg-paper-300/70 rounded w-5/6" />
+            <div className="h-4 bg-paper-300/70 rounded w-1/2" />
           </div>
         </div>
       ))}
@@ -77,26 +78,30 @@ export default function Home() {
 
   return (
     <div>
-      {/* ── Hero ───────────────────────────────────────────────────────── */}
+      {/* ── Hero — sumi-ink surface with a faint crane and persimmon accent ─── */}
       <div className="-mx-4 sm:-mx-6 lg:-mx-8 mb-14">
-        <div className="relative overflow-hidden bg-gradient-to-br from-blue-950/70 via-[#111827] to-purple-950/50 border-b border-white/5 px-4 sm:px-6 lg:px-8 py-16">
-          {/* decorative blobs */}
-          <div className="absolute -top-32 -left-32 w-[32rem] h-[32rem] bg-blue-600/10 rounded-full blur-3xl pointer-events-none" />
-          <div className="absolute -bottom-32 right-0 w-[32rem] h-[32rem] bg-purple-600/10 rounded-full blur-3xl pointer-events-none" />
+        <div className="relative overflow-hidden bg-ink-900 px-4 sm:px-6 lg:px-8 py-16 sm:py-20">
+          {/* faint crane watermark */}
+          <CraneMark
+            size={420}
+            className="absolute -right-16 -top-10 text-persimmon-400/10 rotate-6 pointer-events-none hidden sm:block"
+          />
+          {/* soft warm highlight */}
+          <div className="absolute -top-24 left-1/4 w-[34rem] h-[34rem] bg-persimmon-500/10 rounded-full blur-3xl pointer-events-none" />
 
           <div className="relative max-w-2xl">
-            <span className="inline-block border border-blue-500/30 bg-blue-500/10 text-blue-400 text-xs font-semibold uppercase tracking-widest px-3 py-1 rounded-full mb-5">
-              Grulla Comenta
+            <span className="gc-kicker text-persimmon-300 block mb-5">
+              Lecturas lentas · Opiniones cuidadas
             </span>
-            <h1 className="text-4xl sm:text-5xl font-extrabold text-white leading-tight mb-4">
-              Anime &amp; Manga
+            <h1 className="font-display text-4xl sm:text-5xl font-black text-paper-100 leading-tight mb-4">
+              Ensayos sobre anime, manga y videojuegos
             </h1>
-            <p className="text-gray-400 text-lg leading-relaxed mb-8">
+            <p className="font-body text-ink-300 text-lg leading-relaxed mb-8">
               {t('subtitle')}
             </p>
             <Link
               href={`/${locale}/anime-manga`}
-              className="inline-flex items-center gap-2 bg-blue-600 hover:bg-blue-500 text-white font-semibold px-6 py-3 rounded-xl transition-colors"
+              className="inline-flex items-center gap-2 bg-persimmon-500 hover:bg-persimmon-600 text-[#FFF8F0] font-ui font-bold px-6 py-3 rounded-pill shadow-md transition-colors active:translate-y-px"
             >
               {t('viewAllReviews')}
               <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
@@ -107,27 +112,27 @@ export default function Home() {
         </div>
       </div>
 
-      {/* ── Sections ───────────────────────────────────────────────────── */}
+      {/* ── Sections ───────────────────────────────────────────────────────── */}
       <div className="space-y-14">
 
-        {/* Anime */}
+        {/* Anime — persimmon accent */}
         <section aria-label="Anime">
           <div className="flex items-end justify-between mb-7">
             <div className="flex items-center gap-3">
-              <div className="w-1 h-9 bg-blue-500 rounded-full" aria-hidden="true" />
+              <div className="w-1 h-9 bg-persimmon-500 rounded-pill" aria-hidden="true" />
               <div>
-                <h2 className="text-xl font-bold text-white leading-none mb-0.5">Anime</h2>
+                <h2 className="font-display text-2xl font-bold text-ink-900 leading-none mb-1">Anime</h2>
                 {!loading && (
-                  <p className="text-xs text-gray-500">
+                  <p className="text-xs text-ink-500">
                     {animeReviews.length}{' '}
-                    {animeReviews.length === 1 ? 'reseña' : 'reseñas'}
+                    {animeReviews.length === 1 ? 'ensayo' : 'ensayos'}
                   </p>
                 )}
               </div>
             </div>
             <Link
               href={`/${locale}/anime-manga`}
-              className="text-sm text-blue-400 hover:text-blue-300 font-medium flex items-center gap-1 transition-colors"
+              className="text-sm text-persimmon-600 hover:text-persimmon-700 font-ui font-bold flex items-center gap-1 transition-colors"
             >
               {tCommon('viewAll')} <ChevronRight />
             </Link>
@@ -138,32 +143,32 @@ export default function Home() {
           ) : animeReviews.length > 0 ? (
             <ReviewGrid reviews={animeReviews} />
           ) : (
-            <div className="text-center text-gray-500 py-10 bg-gray-800/20 rounded-xl border border-gray-800/40">
+            <div className="text-center text-ink-500 py-10 bg-paper-50 rounded-xl border border-border">
               {t('noAnimePosts')}
             </div>
           )}
         </section>
 
-        <div className="border-t border-gray-800/50" />
+        <div className="border-t border-divider" />
 
-        {/* Manga */}
+        {/* Manga — indigo accent */}
         <section aria-label="Manga">
           <div className="flex items-end justify-between mb-7">
             <div className="flex items-center gap-3">
-              <div className="w-1 h-9 bg-violet-500 rounded-full" aria-hidden="true" />
+              <div className="w-1 h-9 bg-indigo-500 rounded-pill" aria-hidden="true" />
               <div>
-                <h2 className="text-xl font-bold text-white leading-none mb-0.5">Manga</h2>
+                <h2 className="font-display text-2xl font-bold text-ink-900 leading-none mb-1">Manga</h2>
                 {!loading && (
-                  <p className="text-xs text-gray-500">
+                  <p className="text-xs text-ink-500">
                     {mangaReviews.length}{' '}
-                    {mangaReviews.length === 1 ? 'reseña' : 'reseñas'}
+                    {mangaReviews.length === 1 ? 'ensayo' : 'ensayos'}
                   </p>
                 )}
               </div>
             </div>
             <Link
               href={`/${locale}/anime-manga`}
-              className="text-sm text-violet-400 hover:text-violet-300 font-medium flex items-center gap-1 transition-colors"
+              className="text-sm text-indigo-500 hover:text-indigo-600 font-ui font-bold flex items-center gap-1 transition-colors"
             >
               {tCommon('viewAll')} <ChevronRight />
             </Link>
@@ -174,7 +179,7 @@ export default function Home() {
           ) : mangaReviews.length > 0 ? (
             <ReviewGrid reviews={mangaReviews} />
           ) : (
-            <div className="text-center text-gray-500 py-10 bg-gray-800/20 rounded-xl border border-gray-800/40">
+            <div className="text-center text-ink-500 py-10 bg-paper-50 rounded-xl border border-border">
               {t('noMangaPosts')}
             </div>
           )}

--- a/src/app/[locale]/reviews/[slug]/page.tsx
+++ b/src/app/[locale]/reviews/[slug]/page.tsx
@@ -7,6 +7,7 @@ import { format } from 'date-fns';
 import { ArrowLeftIcon } from '@heroicons/react/24/outline';
 import { useTranslations, useLocale } from 'next-intl';
 import ReviewGrid from '@/components/ReviewGrid';
+import { CraneRating } from '@/components/Crane';
 import { getLocalizedContent, hasContentForLocale, getLocalizedTitle, hasTitleForLocale, extractYouTubeVideoId, createYouTubeEmbedUrl } from '@/lib/utils';
 
 interface Review {
@@ -84,7 +85,7 @@ export default function ReviewPage({ params }: { params: { slug: string } }) {
   if (loading) {
     return (
       <div className="flex justify-center items-center h-64">
-        <div className="text-white">{t('loadingReview')}</div>
+        <div className="text-ink-600">{t('loadingReview')}</div>
       </div>
     );
   }
@@ -92,8 +93,8 @@ export default function ReviewPage({ params }: { params: { slug: string } }) {
   if (!review) {
     return (
       <div className="text-center py-12">
-        <h1 className="text-2xl font-bold text-white mb-4">{t('reviewNotFound')}</h1>
-        <Link href={`/${locale}`} className="text-blue-400 hover:text-blue-300">
+        <h1 className="text-2xl font-bold text-ink-900 mb-4">{t('reviewNotFound')}</h1>
+        <Link href={`/${locale}`} className="text-persimmon-600 hover:text-persimmon-700 font-ui font-bold">
           {t('returnToHome')}
         </Link>
       </div>
@@ -107,7 +108,7 @@ export default function ReviewPage({ params }: { params: { slug: string } }) {
       <div className="mb-6">
         <Link
           href={`/${locale}`}
-          className="inline-flex items-center text-blue-400 hover:text-blue-300 text-sm font-medium"
+          className="inline-flex items-center text-persimmon-600 hover:text-persimmon-700 text-sm font-ui font-bold"
         >
           <ArrowLeftIcon className="w-4 h-4 mr-2" />
           {t('backToReviews')}
@@ -115,7 +116,7 @@ export default function ReviewPage({ params }: { params: { slug: string } }) {
       </div>
 
       <article className="space-y-8">
-        <div className="relative aspect-video w-full overflow-hidden rounded-lg">
+        <div className="relative aspect-video w-full overflow-hidden rounded-xl border border-border shadow-sm bg-paper-200">
           <Image
             src={getImageSrc(review)}
             alt={localizedTitle}
@@ -124,28 +125,27 @@ export default function ReviewPage({ params }: { params: { slug: string } }) {
             priority
           />
         </div>
-        
+
         <div className="space-y-6">
-          <div className="flex items-start justify-between">
+          <div className="flex flex-wrap items-start justify-between gap-4">
             <div>
-              <h1 className="text-4xl font-bold text-white mb-2">{localizedTitle}</h1>
-              <p className="text-gray-400 text-lg">{review.category}</p>
+              <span className="gc-kicker block mb-2 capitalize">{review.category}</span>
+              <h1 className="font-display text-4xl font-black text-ink-900 mb-0 leading-tight">{localizedTitle}</h1>
             </div>
-            <div className="text-right">
-              {review.rating && (
-                <div className="text-4xl font-bold text-blue-400 mb-2">{review.rating}/10</div>
+            <div className="text-right space-y-2">
+              {typeof review.rating === 'number' && (
+                <CraneRating rating={review.rating} size={24} showValue />
               )}
-              <time className="text-sm text-gray-400">
-                {format(new Date(review.createdAt), 'MMMM d, yyyy')}
+              <time className="block text-sm text-ink-500">
+                {format(new Date(review.createdAt), 'd MMMM yyyy')}
               </time>
             </div>
           </div>
 
           {/* Title and Content Language Indicators */}
-          <div className="mb-4 space-y-2">
-            <div className="flex items-center space-x-2 text-sm text-gray-400">
-              <span>📄</span>
-              <span>
+          <div className="mb-4 space-y-2 border-t border-divider pt-4">
+            <div className="flex items-center space-x-2 text-sm text-ink-500">
+              <span className="font-ui font-bold text-ink-600">
                 {locale === 'es' ? 'Título en:' : 'Title in:'} 
                 {locale === 'es' && hasTitleForLocale(review, 'es') ? ' Español' : ''}
                 {locale === 'en' && hasTitleForLocale(review, 'en') ? ' English' : ''}
@@ -156,9 +156,8 @@ export default function ReviewPage({ params }: { params: { slug: string } }) {
                   ' Original'}
               </span>
             </div>
-            <div className="flex items-center space-x-2 text-sm text-gray-400">
-              <span>📝</span>
-              <span>
+            <div className="flex items-center space-x-2 text-sm text-ink-500">
+              <span className="font-ui font-bold text-ink-600">
                 {locale === 'es' ? 'Contenido en:' : 'Content in:'} 
                 {locale === 'es' && hasContentForLocale(review, 'es') ? ' Español' : ''}
                 {locale === 'en' && hasContentForLocale(review, 'en') ? ' English' : ''}
@@ -171,10 +170,10 @@ export default function ReviewPage({ params }: { params: { slug: string } }) {
             </div>
           </div>
 
-          <div className="prose prose-invert max-w-none">
+          <div className="gc-prose max-w-prose">
             {getLocalizedContent(review, locale).split('\n').map((paragraph, index) => (
               paragraph.trim() && (
-                <p key={index} className="text-gray-300 text-lg leading-relaxed mb-6">
+                <p key={index} className="mb-6">
                   {paragraph.trim()}
                 </p>
               )
@@ -184,10 +183,10 @@ export default function ReviewPage({ params }: { params: { slug: string } }) {
           {/* YouTube Video Embed */}
           {review.youtubeUrl && (
             <div className="mt-8">
-              <h3 className="text-xl font-semibold text-white mb-4">
+              <h3 className="font-display text-xl font-bold text-ink-900 mb-4">
                 {locale === 'es' ? 'Video relacionado' : 'Related Video'}
               </h3>
-              <div className="relative aspect-video w-full overflow-hidden rounded-lg bg-black">
+              <div className="relative aspect-video w-full overflow-hidden rounded-xl border border-border bg-ink-900">
                 {(() => {
                   const videoId = extractYouTubeVideoId(review.youtubeUrl);
                   if (videoId) {
@@ -215,7 +214,7 @@ export default function ReviewPage({ params }: { params: { slug: string } }) {
       </article>
 
       <section className="mt-12 space-y-6">
-        <h2 className="text-2xl font-bold text-white">{t('relatedReviews')}</h2>
+        <h2 className="font-display text-2xl font-bold text-ink-900">{t('relatedReviews')}</h2>
         <ReviewGrid reviews={relatedReviews} />
       </section>
     </div>

--- a/src/app/[locale]/reviews/page.tsx
+++ b/src/app/[locale]/reviews/page.tsx
@@ -143,7 +143,7 @@ export default function ReviewsPage() {
       <div className="max-w-6xl mx-auto">
         {/* Header */}
         <div className="mb-8">
-          <h1 className="text-4xl font-bold text-gray-900 dark:text-white mb-4">
+          <h1 className="font-display text-4xl font-black text-ink-900 mb-4">
             {t('title')}
           </h1>
           <p className="text-lg text-gray-600 dark:text-gray-300">
@@ -160,7 +160,7 @@ export default function ReviewsPage() {
               placeholder={t('searchPlaceholder') || 'Search reviews...'}
               value={searchTerm}
               onChange={(e) => setSearchTerm(e.target.value)}
-              className="w-full px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+              className="w-full px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-white focus:ring-2 focus:ring-persimmon-400 focus:border-persimmon-400"
             />
           </div>
 
@@ -169,7 +169,7 @@ export default function ReviewsPage() {
             <select
               value={categoryFilter}
               onChange={(e) => setCategoryFilter(e.target.value)}
-              className="w-full px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+              className="w-full px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-white focus:ring-2 focus:ring-persimmon-400 focus:border-persimmon-400"
             >
               <option value="">{t('filterAll')}</option>
               {availableCategories.map(category => (
@@ -186,7 +186,7 @@ export default function ReviewsPage() {
               <select
                 value={platformFilter}
                 onChange={(e) => setPlatformFilter(e.target.value)}
-                className="w-full px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                className="w-full px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-white focus:ring-2 focus:ring-persimmon-400 focus:border-persimmon-400"
               >
                 <option value="">{t('platformAll')}</option>
                 {availablePlatforms.map(platform => (
@@ -227,7 +227,7 @@ export default function ReviewsPage() {
                   setCategoryFilter('');
                   setPlatformFilter('');
                 }}
-                className="mt-4 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
+                className="mt-4 px-5 py-2 bg-persimmon-500 text-[#FFF8F0] font-ui font-bold rounded-pill shadow-sm hover:bg-persimmon-600 transition-colors"
               >
                 {t('clearFilters')}
               </button>

--- a/src/app/[locale]/search/page.tsx
+++ b/src/app/[locale]/search/page.tsx
@@ -63,7 +63,7 @@ export default function SearchPage() {
   if (loading) {
     return (
       <div className="flex justify-center items-center h-64">
-        <div className="text-gray-300">{tCommon('loading')}</div>
+        <div className="text-ink-600">{tCommon('loading')}</div>
       </div>
     );
   }
@@ -71,11 +71,11 @@ export default function SearchPage() {
   return (
     <div className="space-y-8">
       <div>
-        <h1 className="text-3xl font-bold text-white">
+        <h1 className="font-display text-3xl font-bold text-ink-900">
           {searchQuery ? `Search results for "${searchQuery}"` : 'Search Posts'}
         </h1>
         {searchQuery && (
-          <p className="mt-2 text-gray-300">
+          <p className="mt-2 font-body text-ink-600">
             {reviews.length === 0 
               ? 'No posts found matching your search.'
               : `Found ${reviews.length} post${reviews.length !== 1 ? 's' : ''} matching your search.`
@@ -89,14 +89,14 @@ export default function SearchPage() {
       )}
 
       {searchQuery && reviews.length === 0 && !loading && (
-        <div className="text-center text-gray-400 py-8">
+        <div className="text-center text-ink-500 py-8">
           <p>No posts found for "{searchQuery}".</p>
           <p className="mt-2">Try searching with different keywords.</p>
         </div>
       )}
 
       {!searchQuery && (
-        <div className="text-center text-gray-400 py-8">
+        <div className="text-center text-ink-500 py-8">
           <p>Enter a search term to find posts.</p>
         </div>
       )}

--- a/src/app/[locale]/video-games/[platform]/page.tsx
+++ b/src/app/[locale]/video-games/[platform]/page.tsx
@@ -76,7 +76,7 @@ export default function PlatformPage({ params }: { params: { platform: string } 
   if (loading) {
     return (
       <div className="flex justify-center items-center h-64">
-        <div className="text-gray-300">{t('loadingReviews')}</div>
+        <div className="text-ink-600">{t('loadingReviews')}</div>
       </div>
     );
   }
@@ -84,23 +84,24 @@ export default function PlatformPage({ params }: { params: { platform: string } 
   return (
     <div className="space-y-8">
       <div>
-        <h1 className="text-3xl font-bold text-white">
+        <span className="gc-kicker block mb-2">Videojuegos</span>
+        <h1 className="font-display text-3xl font-bold text-ink-900">
           {platformName} {t('videoGamesTitle')}
         </h1>
-        <p className="mt-2 text-gray-300">
+        <p className="mt-2 font-body text-ink-600">
           {t('videoGamesDescription')} - {platformName}
         </p>
       </div>
-      
-      <div className="flex flex-wrap gap-4">
+
+      <div className="flex flex-wrap gap-3">
         {platforms.map((p) => (
           <Link
             key={p.name}
             href={p.href}
-            className={`px-4 py-2 text-sm font-medium rounded-md transition-colors ${
+            className={`px-4 py-2 text-sm font-ui font-bold rounded-pill transition-colors ${
               p.href === `/${locale}/video-games/${platform}`
-                ? 'bg-blue-600 text-white'
-                : 'text-gray-700 bg-gray-100 hover:bg-gray-200'
+                ? 'bg-persimmon-500 text-[#FFF8F0] shadow-sm'
+                : 'text-ink-700 bg-paper-200 hover:bg-paper-300'
             }`}
           >
             {p.name}
@@ -111,7 +112,7 @@ export default function PlatformPage({ params }: { params: { platform: string } 
       {reviews.length > 0 ? (
         <ReviewGrid reviews={reviews} />
       ) : (
-        <div className="text-center text-gray-400 py-8">
+        <div className="text-center text-ink-500 py-8">
           {t('noReviewsAvailable', { category: platformName })}
         </div>
       )}

--- a/src/app/[locale]/video-games/page.tsx
+++ b/src/app/[locale]/video-games/page.tsx
@@ -75,26 +75,27 @@ export default function VideoGamesPage() {
   if (loading) {
     return (
       <div className="flex justify-center items-center h-64">
-        <div className="text-gray-300">{t('loadingReviews')}</div>
+        <div className="text-ink-600">{t('loadingReviews')}</div>
       </div>
     );
   }
   return (
     <div className="space-y-8">
       <div>
-        <h1 className="text-3xl font-bold text-white">{t('videoGamesTitle')}</h1>
-        <p className="mt-2 text-gray-300">{t('videoGamesDescription')}</p>
+        <span className="gc-kicker block mb-2">Videojuegos</span>
+        <h1 className="font-display text-3xl font-bold text-ink-900">{t('videoGamesTitle')}</h1>
+        <p className="mt-2 font-body text-ink-600">{t('videoGamesDescription')}</p>
       </div>
-      
-      <div className="flex flex-wrap gap-4">
+
+      <div className="flex flex-wrap gap-3">
         {platforms.map((platform) => (
           <button
             key={platform.name}
             onClick={() => handleFilterChange(platform.value)}
-            className={`px-4 py-2 text-sm font-medium rounded-md transition-colors ${
-              activeFilter === platform.value 
-                ? 'bg-blue-600 text-white' 
-                : 'text-gray-700 bg-gray-100 hover:bg-gray-200'
+            className={`px-4 py-2 text-sm font-ui font-bold rounded-pill transition-colors ${
+              activeFilter === platform.value
+                ? 'bg-persimmon-500 text-[#FFF8F0] shadow-sm'
+                : 'text-ink-700 bg-paper-200 hover:bg-paper-300'
             }`}
           >
             {platform.name}
@@ -105,7 +106,7 @@ export default function VideoGamesPage() {
       {filteredReviews.length > 0 ? (
         <ReviewGrid reviews={filteredReviews} />
       ) : (
-        <div className="text-center text-gray-400 py-8">
+        <div className="text-center text-ink-500 py-8">
           {activeFilter === 'all' 
             ? t('noReviewsGeneral')
             : t('noReviewsAvailable', { category: activeFilter })

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2,27 +2,157 @@
 @tailwind components;
 @tailwind utilities;
 
+/* ── Grulla Comenta · Design tokens ───────────────────────────────────────────
+   A warm, cozy palette of traditional Japanese pigments: washi paper, sumi ink,
+   kaki (persimmon), ai (indigo), matcha, kin (gold), azuki. Reach for the
+   semantic aliases in product code; the ramps exist so we can compose new ones.
+   ──────────────────────────────────────────────────────────────────────────── */
+:root {
+  /* Paper / washi — warm cream neutrals */
+  --paper-50: #FFFDF8;
+  --paper-100: #FBF5EB;
+  --paper-200: #F4EAD8;
+  --paper-300: #EADCC2;
+  --paper-400: #DCC9A8;
+
+  /* Sumi ink — warm browny near-blacks */
+  --ink-900: #2A2521;
+  --ink-800: #3B342D;
+  --ink-700: #4F463C;
+  --ink-600: #6B6053;
+  --ink-500: #8B7F70;
+  --ink-400: #A99C8B;
+  --ink-300: #C7BAA8;
+
+  /* Kaki / persimmon — primary accent (柿) */
+  --persimmon-200: #F7CBA8;
+  --persimmon-300: #F0A878;
+  --persimmon-400: #E5814A;
+  --persimmon-500: #D9602E;
+  --persimmon-600: #BC4A20;
+  --persimmon-700: #983819;
+
+  /* Ai / indigo — cool counterweight (藍) */
+  --indigo-300: #8395AB;
+  --indigo-400: #566982;
+  --indigo-500: #3D5169;
+  --indigo-600: #2E3E52;
+  --indigo-700: #22303F;
+
+  /* Matcha (抹茶) · Kin / gold (金) · Azuki (小豆) · Sakura (桜) */
+  --matcha-500: #7E8E4C;
+  --matcha-600: #63713A;
+  --gold-500: #C5953A;
+  --azuki-500: #B14B3E;
+  --sakura-400: #E79CA6;
+
+  /* Semantic surfaces & text */
+  --bg: var(--paper-100);
+  --bg-sunken: var(--paper-200);
+  --surface: var(--paper-50);
+  --surface-raised: #FFFFFF;
+  --surface-ink: var(--ink-900);
+  --text: var(--ink-900);
+  --text-muted: var(--ink-600);
+  --text-subtle: var(--ink-500);
+  --text-on-dark: var(--paper-100);
+  --text-on-dark-muted: var(--ink-300);
+  --text-on-primary: #FFF8F0;
+
+  /* Borders & dividers */
+  --border: #E7D9C2;
+  --border-strong: #D8C4A4;
+  --divider: #EFE4D2;
+
+  /* Brand / primary (persimmon) + accent (indigo) */
+  --primary: var(--persimmon-500);
+  --primary-hover: var(--persimmon-600);
+  --primary-press: var(--persimmon-700);
+  --primary-soft: var(--persimmon-200);
+  --primary-tint: #FBEADD;
+  --accent: var(--indigo-500);
+  --accent-hover: var(--indigo-600);
+
+  /* Genre accents — the three content pillars */
+  --genre-anime: var(--persimmon-500);
+  --genre-manga: var(--indigo-500);
+  --genre-games: var(--matcha-600);
+
+  /* Focus ring */
+  --ring: 0 0 0 3px rgba(217, 96, 46, 0.28);
+
+  /* Radii — soft & rounded is the brand */
+  --radius-sm: 10px;
+  --radius-md: 14px;
+  --radius-lg: 20px;
+  --radius-xl: 28px;
+  --radius-pill: 999px;
+
+  /* Shadows — warm, low, diffuse (sunlight through shoji) */
+  --shadow-xs: 0 1px 2px rgba(74, 48, 24, 0.06);
+  --shadow-sm: 0 2px 6px -1px rgba(74, 48, 24, 0.09);
+  --shadow-md: 0 6px 18px -6px rgba(74, 48, 24, 0.16);
+  --shadow-lg: 0 16px 40px -12px rgba(74, 48, 24, 0.22);
+
+  /* Typography families (wired to next/font in layout.tsx) */
+  --font-display: var(--font-zen-old-mincho), Georgia, serif;
+  --font-body: var(--font-shippori-mincho), Georgia, serif;
+  --font-ui: var(--font-zen-maru-gothic), ui-rounded, system-ui, sans-serif;
+
+  /* Layout */
+  --container: 1200px;
+  --header-h: 72px;
+  --tracking-label: 0.12em;
+}
+
 @layer base {
   body {
-    @apply bg-[#121212] text-gray-100 antialiased;
+    @apply bg-paper-100 text-ink-900 font-ui antialiased;
+  }
+
+  /* Headings default to the editorial serif */
+  h1, h2, h3, h4, h5, h6 {
+    font-family: var(--font-display);
+    text-wrap: balance;
   }
 
   h1 {
-    @apply text-2xl md:text-3xl font-bold text-white mb-4;
+    @apply text-3xl md:text-4xl font-bold text-ink-900 mb-4;
   }
 
   h2 {
-    @apply text-xl md:text-2xl font-bold text-white mb-3;
+    @apply text-2xl md:text-3xl font-bold text-ink-900 mb-3;
   }
 
   h3 {
-    @apply text-lg md:text-xl font-semibold text-white mb-2;
+    @apply text-xl md:text-2xl font-semibold text-ink-900 mb-2;
+  }
+
+  p {
+    text-wrap: pretty;
+  }
+
+  ::selection {
+    background: var(--primary-soft);
+    color: var(--ink-900);
   }
 }
 
 @layer components {
   .container {
     @apply max-w-7xl mx-auto px-4 sm:px-6 lg:px-8;
+  }
+
+  /* Eyebrow / kicker label — recurring brand device */
+  .gc-kicker {
+    @apply font-ui font-bold text-xs uppercase text-persimmon-500;
+    letter-spacing: var(--tracking-label);
+  }
+
+  /* Long-form reading column — the book serif, set large and airy */
+  .gc-prose {
+    font-family: var(--font-body);
+    @apply text-lg leading-[1.75] text-ink-800;
   }
 
   .icon {
@@ -33,59 +163,49 @@
     @apply w-6 h-6;
   }
 
+  /* Pill buttons — rounded is the brand */
   .btn {
-    @apply px-4 py-2 rounded-lg font-medium transition-colors;
+    @apply inline-flex items-center justify-center gap-2 px-5 py-2.5 rounded-pill font-ui font-bold transition-all;
   }
 
   .btn-primary {
-    @apply bg-blue-500 text-white hover:bg-blue-600;
+    @apply bg-persimmon-500 text-[#FFF8F0] shadow-sm hover:bg-persimmon-600 hover:shadow-md active:translate-y-px;
   }
 
   .btn-secondary {
-    @apply bg-gray-700 text-white hover:bg-gray-600;
+    @apply bg-paper-50 text-ink-800 border-2 border-border-strong hover:bg-paper-100 hover:border-ink-400;
   }
 
+  /* Cards — rounded surface, warm hairline border, soft shadow */
   .card {
-    @apply bg-[#1a1a1a] rounded-lg overflow-hidden border border-gray-800 transition-all hover:border-gray-700;
+    @apply bg-paper-50 rounded-lg overflow-hidden border border-border shadow-sm transition-all;
+  }
+
+  .card-interactive {
+    @apply hover:-translate-y-0.5 hover:shadow-md;
   }
 
   .card-body {
-    @apply p-4;
+    @apply p-5;
   }
 
   .review-grid {
     @apply grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6;
   }
 
-  .review-score {
-    @apply text-3xl font-bold text-blue-500;
-  }
-
   .nav-link {
-    @apply text-gray-300 hover:text-white transition-colors;
+    @apply text-ink-600 hover:text-persimmon-500 transition-colors;
   }
 
   .nav-link-active {
-    @apply text-white font-medium;
+    @apply text-persimmon-500 font-medium;
   }
 
   .form-input {
-    @apply w-full px-4 py-2 bg-[#2d2d2d] border border-gray-700 rounded-lg text-white placeholder-gray-400 focus:outline-none focus:border-blue-500;
+    @apply w-full px-4 py-2 bg-paper-50 border border-border-strong rounded-pill text-ink-900 placeholder-ink-500 focus:outline-none focus:border-persimmon-400;
   }
 
-  .table-container {
-    @apply w-full overflow-x-auto;
-  }
-
-  .table {
-    @apply min-w-full divide-y divide-gray-800;
-  }
-
-  .table th {
-    @apply px-6 py-3 text-left text-xs font-medium text-gray-400 uppercase tracking-wider;
-  }
-
-  .table td {
-    @apply px-6 py-4 whitespace-nowrap text-sm text-gray-300;
+  .form-input:focus-visible {
+    box-shadow: var(--ring);
   }
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,18 +1,37 @@
 import type { Metadata } from "next";
-import { Inter } from 'next/font/google';
+import { Zen_Old_Mincho, Shippori_Mincho, Zen_Maru_Gothic } from 'next/font/google';
 import "./globals.css";
 import Providers from "@/components/Providers";
 import { defaultLocale } from "@/i18n/request";
 
-const inter = Inter({ 
+// ── Grulla Comenta type pairing ──────────────────────────────────────────────
+// Zen Old Mincho   — editorial serif for titles, heroes, section heads
+// Shippori Mincho  — book serif for long-form essay reading
+// Zen Maru Gothic  — rounded gothic for buttons, labels, nav (the roundness is the cozy)
+const zenOldMincho = Zen_Old_Mincho({
   subsets: ['latin'],
+  weight: ['400', '500', '700', '900'],
   display: 'swap',
-  variable: '--font-inter',
+  variable: '--font-zen-old-mincho',
+});
+
+const shipporiMincho = Shippori_Mincho({
+  subsets: ['latin'],
+  weight: ['400', '500', '600', '700'],
+  display: 'swap',
+  variable: '--font-shippori-mincho',
+});
+
+const zenMaruGothic = Zen_Maru_Gothic({
+  subsets: ['latin'],
+  weight: ['400', '500', '700', '900'],
+  display: 'swap',
+  variable: '--font-zen-maru-gothic',
 });
 
 export const metadata: Metadata = {
   title: "Grulla Comenta - Anime, Manga y Videojuegos",
-  description: "Grulla Comenta es un blog de comentarios sobre anime, manga y videojuegos.",
+  description: "Grulla Comenta es un lugar para guardar y exponer ensayos sobre anime, manga y videojuegos. Lecturas lentas, opiniones cuidadas.",
   icons: {
     icon: '/minilogo.png',
     shortcut: '/minilogo.png',
@@ -25,9 +44,10 @@ export default function RootLayout({
 }: {
   children: React.ReactNode
 }) {
+  const fontVars = `${zenOldMincho.variable} ${shipporiMincho.variable} ${zenMaruGothic.variable}`;
   return (
-    <html lang={defaultLocale} className={inter.variable}>
-      <body className={`${inter.className} min-h-screen bg-dark text-gray-100`}>
+    <html lang={defaultLocale} className={fontVars}>
+      <body className="min-h-screen bg-paper-100 text-ink-900 font-ui">
         <Providers>
           {children}
         </Providers>

--- a/src/components/Crane.tsx
+++ b/src/components/Crane.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+// ── Grulla Comenta · the origami crane (orizuru) ─────────────────────────────
+// A faceted paper-crane drawn with currentColor so it recolors cleanly. It is
+// the logomark, the rating glyph, and a faint watermark on cover art.
+
+function CranePaths() {
+  return (
+    <>
+      <path d="M41 39 L31 5 L60 19 Z" opacity="0.55" />
+      <path d="M41 39 L31 5 L40 24 Z" opacity="0.8" />
+      <path d="M41 39 L78 23 L62 41 Z" opacity="0.62" />
+      <path d="M41 39 L7 28 L23 42 Z" opacity="0.9" />
+      <path d="M9 28 L1 33 L13 33 Z" />
+      <path d="M41 39 L23 42 L38 63 Z" />
+      <path d="M41 39 L38 63 L53 55 Z" opacity="0.72" />
+    </>
+  );
+}
+
+export function CraneMark({
+  size = 28,
+  className = '',
+}: {
+  size?: number;
+  className?: string;
+}) {
+  return (
+    <svg
+      viewBox="0 0 80 80"
+      fill="currentColor"
+      width={size}
+      height={size}
+      className={className}
+      aria-hidden="true"
+    >
+      <CranePaths />
+    </svg>
+  );
+}
+
+/**
+ * Crane rating — the brand's review metric. Ratings are measured in **grullas**
+ * (cranes), not stars. Reviews are scored out of 10; we render 5 cranes filled
+ * proportionally and show the numeric score alongside.
+ */
+export function CraneRating({
+  rating,
+  outOf = 10,
+  size = 18,
+  showValue = true,
+  className = '',
+}: {
+  rating: number;
+  outOf?: number;
+  size?: number;
+  showValue?: boolean;
+  className?: string;
+}) {
+  const cranes = 5;
+  const filled = Math.round((rating / outOf) * cranes);
+  return (
+    <span
+      className={`inline-flex items-center gap-1.5 font-ui ${className}`}
+      role="img"
+      aria-label={`${rating} de ${outOf} grullas`}
+    >
+      <span className="inline-flex gap-0.5">
+        {Array.from({ length: cranes }, (_, i) => (
+          <CraneMark
+            key={i}
+            size={size}
+            className={i < filled ? 'text-persimmon-500' : 'text-ink-300'}
+          />
+        ))}
+      </span>
+      {showValue && (
+        <span className="font-bold text-sm text-ink-700">
+          {rating}
+          <span className="text-ink-400">/{outOf}</span>
+        </span>
+      )}
+    </span>
+  );
+}
+
+export default CraneMark;

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -2,10 +2,10 @@
 
 import { useState, useEffect } from 'react';
 import Link from 'next/link';
-import Image from 'next/image';
 import { useRouter } from 'next/navigation';
 import { useTranslations, useLocale } from 'next-intl';
 import { MagnifyingGlassIcon } from '@heroicons/react/24/outline';
+import { CraneMark } from './Crane';
 import LanguageSwitcher from './LanguageSwitcher';
 
 interface CategoryData {
@@ -37,7 +37,6 @@ export default function Header() {
       const response = await fetch('/api/categories');
       if (response.ok) {
         const data: AvailableCategoriesResponse = await response.json();
-        console.log('Available categories:', data.categories);
         setAvailableCategories(data.categories);
       }
     } catch (error) {
@@ -49,42 +48,28 @@ export default function Header() {
 
   const buildNavigationItems = () => {
     const items = [];
-    
-    // Always show "All Reviews" if there are any reviews
+
     if (availableCategories.length > 0) {
-      items.push({
-        name: tCategories('all'),
-        href: `/${locale}/reviews`
-      });
+      items.push({ name: tCategories('all'), href: `/${locale}/reviews` });
     }
 
-    // Check if we have anime or manga reviews
     const hasAnime = availableCategories.some(cat => cat.category === 'anime');
     const hasManga = availableCategories.some(cat => cat.category === 'manga');
-    
-    // Show "Anime and Manga" if we have either anime or manga reviews
+
     if (hasAnime || hasManga) {
-      items.push({
-        name: tCategories('anime'),
-        href: `/${locale}/anime-manga`
-      });
+      items.push({ name: tCategories('anime'), href: `/${locale}/anime-manga` });
     }
 
-    // Add video games category and its platforms
     const videoGamesCategory = availableCategories.find(cat => cat.category === 'video-games');
     if (videoGamesCategory) {
-      items.push({
-        name: tCategories('videoGames'),
-        href: `/${locale}/video-games`
-      });
-      
-      // Add platforms for video games if they exist
+      items.push({ name: tCategories('videoGames'), href: `/${locale}/video-games` });
+
       videoGamesCategory.platforms.forEach(platform => {
         const platformKey = platform.toLowerCase();
         if (['playstation', 'xbox', 'nintendo', 'pc'].includes(platformKey)) {
           items.push({
             name: tCategories(platformKey),
-            href: `/${locale}/video-games/${platformKey}`
+            href: `/${locale}/video-games/${platformKey}`,
           });
         }
       });
@@ -104,76 +89,73 @@ export default function Header() {
   };
 
   return (
-    <header className="bg-[#1a1a1a] text-white">
+    <header className="sticky top-0 z-20 bg-paper-50/85 backdrop-blur-md border-b border-border">
       {/* Main Header */}
-      <div className="border-b border-gray-800">
-        <div className="container mx-auto px-4">
-          <div className="flex items-center justify-between h-16">
-            <Link href={`/${locale}`} className="flex items-center hover:opacity-90 transition-opacity">
-              <Image
-                src="/logo.png"
-                alt="Grulla Comenta"
-                width={280}
-                height={46}
-                className="object-contain w-48 h-8 sm:w-56 sm:h-9 md:w-64 md:h-10 lg:w-72 lg:h-12"
-                priority
+      <div className="container mx-auto px-4">
+        <div className="flex items-center justify-between h-[72px] gap-4">
+          <Link
+            href={`/${locale}`}
+            className="flex items-center gap-2.5 hover:opacity-90 transition-opacity"
+          >
+            <CraneMark size={30} className="text-persimmon-500" />
+            <span className="font-display font-black text-xl sm:text-2xl text-ink-900 tracking-tight">
+              Grulla Comenta
+            </span>
+          </Link>
+
+          <div className="flex items-center gap-2 sm:gap-4">
+            {/* Desktop search */}
+            <form onSubmit={handleSearch} className="relative hidden sm:block w-48 md:w-64">
+              <input
+                type="search"
+                placeholder={t('search') || 'Buscar ensayos…'}
+                className="w-full px-4 py-1.5 pr-10 text-sm bg-paper-100 border border-border-strong rounded-pill text-ink-900 placeholder-ink-500 focus:outline-none focus:border-persimmon-400 [&::-webkit-search-cancel-button]:appearance-none [&::-webkit-search-decoration]:appearance-none"
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
               />
-            </Link>
-            
-            <div className="flex items-center space-x-2 sm:space-x-4">
-              {/* Desktop search */}
-              <form onSubmit={handleSearch} className="relative hidden sm:block w-48 md:w-64">
-                <input
-                  type="search"
-                  placeholder={t('search') || 'Search posts...'}
-                  className="w-full px-4 py-1.5 pr-10 text-sm bg-[#2d2d2d] border border-gray-700 rounded-full text-white placeholder-gray-400 focus:outline-none focus:border-blue-500 [&::-webkit-search-cancel-button]:appearance-none [&::-webkit-search-decoration]:appearance-none"
-                  value={searchQuery}
-                  onChange={(e) => setSearchQuery(e.target.value)}
-                />
-                <MagnifyingGlassIcon className="absolute right-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-400 pointer-events-none" />
-              </form>
-              
-              {/* Mobile search icon */}
-              <button
-                onClick={() => setShowMobileSearch(!showMobileSearch)}
-                className="sm:hidden p-2 text-gray-400 hover:text-white"
-                aria-label={t('search')}
-                aria-expanded={showMobileSearch}
-              >
-                <MagnifyingGlassIcon className="h-5 w-5" aria-hidden="true" />
-              </button>
-              <LanguageSwitcher />
-            </div>
+              <MagnifyingGlassIcon className="absolute right-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-ink-500 pointer-events-none" />
+            </form>
+
+            {/* Mobile search icon */}
+            <button
+              onClick={() => setShowMobileSearch(!showMobileSearch)}
+              className="sm:hidden p-2 text-ink-500 hover:text-persimmon-500"
+              aria-label={t('search')}
+              aria-expanded={showMobileSearch}
+            >
+              <MagnifyingGlassIcon className="h-5 w-5" aria-hidden="true" />
+            </button>
+            <LanguageSwitcher />
           </div>
         </div>
       </div>
 
       {/* Mobile search bar */}
       {showMobileSearch && (
-        <div className="sm:hidden bg-[#1a1a1a] border-b border-gray-800 px-4 py-3">
+        <div className="sm:hidden bg-paper-50 border-t border-border px-4 py-3">
           <form onSubmit={handleSearch} className="relative">
             <input
               type="search"
-              placeholder={t('search') || 'Search posts...'}
-              className="w-full px-4 py-2 pr-10 text-sm bg-[#2d2d2d] border border-gray-700 rounded-full text-white placeholder-gray-400 focus:outline-none focus:border-blue-500 [&::-webkit-search-cancel-button]:appearance-none [&::-webkit-search-decoration]:appearance-none"
+              placeholder={t('search') || 'Buscar ensayos…'}
+              className="w-full px-4 py-2 pr-10 text-sm bg-paper-100 border border-border-strong rounded-pill text-ink-900 placeholder-ink-500 focus:outline-none focus:border-persimmon-400 [&::-webkit-search-cancel-button]:appearance-none [&::-webkit-search-decoration]:appearance-none"
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
               autoFocus
             />
-            <MagnifyingGlassIcon className="absolute right-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-400 pointer-events-none" />
+            <MagnifyingGlassIcon className="absolute right-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-ink-500 pointer-events-none" />
           </form>
         </div>
       )}
 
       {/* Category Navigation */}
-      <div className="border-b border-gray-800">
+      <div className="border-t border-border">
         <nav className="container mx-auto px-4">
-          <div className="flex items-center space-x-6 h-12 overflow-x-auto">
+          <div className="flex items-center gap-1 h-12 overflow-x-auto">
             {!loading && navigationItems.map((item) => (
               <Link
                 key={item.name}
                 href={item.href}
-                className="text-sm font-medium text-gray-300 hover:text-white whitespace-nowrap transition-colors"
+                className="text-sm font-ui font-bold text-ink-600 hover:text-persimmon-500 hover:bg-paper-200 px-3 py-1.5 rounded-pill whitespace-nowrap transition-colors"
               >
                 {item.name}
               </Link>
@@ -183,4 +165,4 @@ export default function Header() {
       </div>
     </header>
   );
-} 
+}

--- a/src/components/LanguageSwitcher.tsx
+++ b/src/components/LanguageSwitcher.tsx
@@ -33,7 +33,7 @@ export default function LanguageSwitcher() {
     <div className="relative">
       <button
         onClick={() => setIsOpen(!isOpen)}
-        className="flex items-center space-x-2 px-3 py-1.5 text-sm bg-[#2d2d2d] border border-gray-700 rounded-md text-white hover:bg-[#3d3d3d] transition-colors"
+        className="flex items-center space-x-2 px-3 py-1.5 text-sm font-ui font-bold bg-paper-100 border border-border-strong rounded-pill text-ink-700 hover:bg-paper-200 transition-colors"
       >
         <GlobeAltIcon className="h-4 w-4" />
         <span className="hidden sm:inline">{currentLanguage?.flag}</span>
@@ -42,13 +42,13 @@ export default function LanguageSwitcher() {
       </button>
 
       {isOpen && (
-        <div className="absolute right-0 mt-1 w-40 bg-[#2d2d2d] border border-gray-700 rounded-md shadow-lg z-50">
+        <div className="absolute right-0 mt-1 w-40 bg-paper-50 border border-border rounded-md shadow-lg z-50 overflow-hidden">
           {languages.map((language) => (
             <button
               key={language.code}
               onClick={() => switchLanguage(language.code)}
-              className={`w-full text-left px-3 py-2 text-sm hover:bg-[#3d3d3d] transition-colors flex items-center space-x-2 ${
-                locale === language.code ? 'bg-[#3d3d3d] text-blue-400' : 'text-white'
+              className={`w-full text-left px-3 py-2 text-sm font-ui hover:bg-paper-200 transition-colors flex items-center space-x-2 ${
+                locale === language.code ? 'bg-paper-200 text-persimmon-600 font-bold' : 'text-ink-700'
               }`}
             >
               <span>{language.flag}</span>

--- a/src/components/ReviewGrid.tsx
+++ b/src/components/ReviewGrid.tsx
@@ -5,6 +5,7 @@ import Image from 'next/image';
 import { format } from 'date-fns';
 import { useLocale } from 'next-intl';
 import { getLocalizedTitle } from '@/lib/utils';
+import { CraneRating } from './Crane';
 
 interface Review {
   id: string;
@@ -32,63 +33,78 @@ interface ReviewGridProps {
   showCategory?: boolean;
 }
 
+// Genre accents — the three content pillars (matches the design system Tag).
+const GENRE_STYLES: Record<string, string> = {
+  anime: 'bg-persimmon-500/[0.14] text-persimmon-600',
+  manga: 'bg-indigo-500/[0.14] text-indigo-500',
+  'video-games': 'bg-matcha-600/[0.16] text-matcha-600',
+};
+
+function GenreTag({ label, category }: { label: string; category: string }) {
+  const style = GENRE_STYLES[category] ?? 'bg-ink-600/[0.12] text-ink-600';
+  return (
+    <span
+      className={`inline-flex items-center rounded-pill px-2.5 py-1 text-xs font-ui font-bold capitalize ${style}`}
+    >
+      {label}
+    </span>
+  );
+}
+
 export default function ReviewGrid({ reviews, showCategory = true }: ReviewGridProps) {
   const locale = useLocale();
-  
+
   const getImageSrc = (review: Review) => {
-    // If there's uploaded image data, use the API endpoint with cache busting
     if (review.imageData) {
       const timestamp = review.updatedAt ? new Date(review.updatedAt).getTime() : Date.now();
       return `/api/images/${review.id}?v=${timestamp}`;
     }
-    // Otherwise use the coverImage URL
     return review.coverImage || '/images/placeholder.jpg';
   };
 
   return (
-    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-5 gap-6">
+    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
       {reviews.map((review) => {
         const localizedTitle = getLocalizedTitle(review, locale);
-        
+
         return (
-          <Link 
-            key={review.id} 
+          <Link
+            key={review.id}
             href={`/${locale}/reviews/${review.slug}`}
-            className="group bg-gray-800 rounded-lg overflow-hidden hover:bg-gray-700 transition-colors"
+            className="group flex flex-col bg-paper-50 rounded-lg overflow-hidden border border-border shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:shadow-md"
           >
-            <div className="relative aspect-video overflow-hidden">
+            <div className="relative aspect-video overflow-hidden bg-paper-200">
               <Image
                 src={getImageSrc(review)}
                 alt={localizedTitle}
                 fill
                 className="object-cover group-hover:scale-105 transition-transform duration-300"
-                sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 20vw"
+                sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 25vw"
               />
             </div>
-            <div className="p-4">
-              <h3 className="text-lg font-bold text-white group-hover:text-blue-400 transition-colors line-clamp-2">
+            <div className="flex flex-col gap-3 p-5">
+              <div className="flex items-center gap-2">
+                {showCategory && (
+                  <GenreTag label={review.platform || review.category} category={review.category} />
+                )}
+                <span className="font-ui text-xs text-ink-500">
+                  {format(new Date(review.date), 'd MMM yyyy')}
+                </span>
+              </div>
+
+              <h3 className="font-display text-xl font-bold leading-tight text-ink-900 group-hover:text-persimmon-600 transition-colors line-clamp-2">
                 {localizedTitle}
               </h3>
-              {showCategory && (
-                <p className="text-sm font-medium text-gray-300 mt-1">
-                  {review.platform || review.category}
-                </p>
+
+              {typeof review.rating === 'number' && (
+                <div className="mt-auto pt-1">
+                  <CraneRating rating={review.rating} size={16} />
+                </div>
               )}
-              {review.rating && (
-                <p
-                  className="text-sm font-medium text-blue-400 mt-1"
-                  aria-label={`Rating: ${review.rating} out of 10`}
-                >
-                  <span aria-hidden="true">⭐ {review.rating}/10</span>
-                </p>
-              )}
-              <p className="text-sm text-gray-400 mt-2">
-                {format(new Date(review.date), 'MMMM d, yyyy')}
-              </p>
             </div>
           </Link>
         );
       })}
     </div>
   );
-} 
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -8,6 +8,72 @@ module.exports = {
   theme: {
     extend: {
       colors: {
+        // ── Grulla Comenta · traditional Japanese pigment palette ──────────
+        // Washi paper — warm cream neutrals (backgrounds & surfaces)
+        paper: {
+          50: '#FFFDF8',
+          100: '#FBF5EB',
+          200: '#F4EAD8',
+          300: '#EADCC2',
+          400: '#DCC9A8',
+        },
+        // Sumi ink — warm browny near-blacks (text & strong surfaces)
+        ink: {
+          300: '#C7BAA8',
+          400: '#A99C8B',
+          500: '#8B7F70',
+          600: '#6B6053',
+          700: '#4F463C',
+          800: '#3B342D',
+          900: '#2A2521',
+        },
+        // Kaki / persimmon — the primary warm accent (柿)
+        persimmon: {
+          200: '#F7CBA8',
+          300: '#F0A878',
+          400: '#E5814A',
+          500: '#D9602E',
+          600: '#BC4A20',
+          700: '#983819',
+        },
+        // Ai / indigo — the cool counterweight (藍)
+        indigo: {
+          300: '#8395AB',
+          400: '#566982',
+          500: '#3D5169',
+          600: '#2E3E52',
+          700: '#22303F',
+        },
+        // Matcha — moss green (抹茶)
+        matcha: {
+          300: '#B6C089',
+          400: '#9BAA66',
+          500: '#7E8E4C',
+          600: '#63713A',
+        },
+        // Kin / gold — kintsugi amber (金)
+        gold: {
+          300: '#EBCB82',
+          400: '#DDB257',
+          500: '#C5953A',
+          600: '#A2772B',
+        },
+        // Azuki — deep red bean (小豆), for danger
+        azuki: {
+          400: '#C56657',
+          500: '#B14B3E',
+          600: '#8F3A30',
+        },
+        // Sakura — soft rose, decorative tertiary (桜)
+        sakura: {
+          300: '#F2C7CC',
+          400: '#E79CA6',
+        },
+        // Semantic helpers
+        border: '#E7D9C2',
+        'border-strong': '#D8C4A4',
+        divider: '#EFE4D2',
+        // Keep legacy admin (dark) palette working
         dark: {
           DEFAULT: '#121212',
           100: '#1a1a1a',
@@ -18,30 +84,46 @@ module.exports = {
           600: '#999999',
           700: '#a3a3a3',
           800: '#d4d4d4',
-          900: '#ffffff'
+          900: '#ffffff',
         },
         accent: {
-          DEFAULT: '#3b82f6',
-          hover: '#2563eb'
-        }
+          DEFAULT: '#3D5169',
+          hover: '#2E3E52',
+        },
       },
       fontFamily: {
-        sans: ['Inter', 'system-ui', 'sans-serif'],
+        display: ['var(--font-display)', 'Georgia', 'serif'],
+        body: ['var(--font-body)', 'Georgia', 'serif'],
+        ui: ['var(--font-ui)', 'ui-rounded', 'system-ui', 'sans-serif'],
+        sans: ['var(--font-ui)', 'system-ui', 'sans-serif'],
       },
-      fontSize: {
-        'xs': ['0.75rem', { lineHeight: '1rem' }],
-        'sm': ['0.875rem', { lineHeight: '1.25rem' }],
-        'base': ['1rem', { lineHeight: '1.5rem' }],
-        'lg': ['1.125rem', { lineHeight: '1.75rem' }],
-        'xl': ['1.25rem', { lineHeight: '1.75rem' }],
-        '2xl': ['1.5rem', { lineHeight: '2rem' }],
-        '3xl': ['1.875rem', { lineHeight: '2.25rem' }],
-        '4xl': ['2.25rem', { lineHeight: '2.5rem' }],
+      borderRadius: {
+        xs: '6px',
+        sm: '10px',
+        md: '14px',
+        lg: '20px',
+        xl: '28px',
+        '2xl': '36px',
+        pill: '999px',
+      },
+      boxShadow: {
+        // Warm, low, diffuse — sunlight through shoji paper
+        xs: '0 1px 2px rgba(74, 48, 24, 0.06)',
+        sm: '0 2px 6px -1px rgba(74, 48, 24, 0.09)',
+        md: '0 6px 18px -6px rgba(74, 48, 24, 0.16)',
+        lg: '0 16px 40px -12px rgba(74, 48, 24, 0.22)',
+        xl: '0 28px 64px -16px rgba(58, 38, 18, 0.26)',
+      },
+      letterSpacing: {
+        label: '0.12em',
+      },
+      maxWidth: {
+        prose: '720px',
       },
       spacing: {
-        '18': '4.5rem',
-        '112': '28rem',
-        '128': '32rem',
+        18: '4.5rem',
+        112: '28rem',
+        128: '32rem',
       },
     },
   },
@@ -49,4 +131,3 @@ module.exports = {
     require('@tailwindcss/typography'),
   ],
 }
-


### PR DESCRIPTION
Implements the **Grulla Comenta** design system (handed off from Claude Design) across the public-facing site, replacing the dark-blue + Inter theme with the warm "washi tea-house" aesthetic: washi-paper backgrounds, sumi-ink text, a persimmon (kaki) accent, Japanese serifs, generous rounding, and the origami-crane motif.

## Foundations
- Japanese-pigment palette (washi paper, sumi ink, kaki/persimmon primary, ai/indigo, matcha, gold, azuki, sakura) added to the Tailwind theme, plus soft radii and warm diffuse shadows.
- Type pairing wired via `next/font`: **Zen Old Mincho** (display), **Shippori Mincho** (book serif for reading), **Zen Maru Gothic** (rounded UI).
- `globals.css` rewritten with design tokens, a light washi base layer, and the `.gc-kicker` eyebrow + `.gc-prose` reading-column helpers.

## Brand
- Origami-crane logomark added (`public/logo-crane.svg`) and a reusable `Crane` component: `CraneMark` + the signature `CraneRating` (reviews are scored in **cranes, not stars**).

## Surfaces
- **Header** — light washi sticky bar with crane mark, serif wordmark, persimmon nav; language switcher retoned.
- **Home** — sumi-ink hero with crane watermark + persimmon CTA; persimmon/indigo section accents.
- **Essay cards** (`ReviewGrid`) — rounded warm surfaces, genre tags, serif titles, crane ratings.
- **Reading view** + anime-manga / video-games / reviews / search pages retoned to the warm palette with serif headings.

## Verification
- `npm install` → `next build` passes (exit 0, all routes build).
- Confirmed the compiled CSS contains the tokens (`.bg-paper-100` → `#FBF5EB`, `.text-ink-900` → `#2A2521`, persimmon `#D9602E`) and that the three fonts load via `next/font`.

## Notes
- **Admin** pages are intentionally left on their dark theme — internal tooling, not brand-facing.
- Per the design system's own caveats, the **fonts and crane logo are original substitutions** (no real brand assets were provided). Swap in real assets when available.

https://claude.ai/code/session_01HNYdHT9JAWy8b1aJR5qj3c

---
_Generated by [Claude Code](https://claude.ai/code/session_01HNYdHT9JAWy8b1aJR5qj3c)_