### PR TITLE
Fix 429 errors on fast navigation for anonymous users

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -14,10 +14,12 @@ const intlMiddleware = createIntlMiddleware({
   localePrefix: 'always'
 });
 
-// Create a new ratelimiter that allows 10 requests per 10 seconds
+// Create a new ratelimiter that allows 50 requests per 10 seconds.
+// The window is generous because Next.js prefetches every visible <Link>
+// href, so a single page load can fire many requests against one IP.
 const ratelimit = new Ratelimit({
   redis: Redis.fromEnv(),
-  limiter: Ratelimit.slidingWindow(10, '10 s'),
+  limiter: Ratelimit.slidingWindow(50, '10 s'),
   analytics: true,
   prefix: '@upstash/ratelimit',
 });
@@ -97,6 +99,18 @@ export default async function middleware(req: NextRequestWithAuth) {
   // Next.js prefetches all visible <Link> hrefs simultaneously, which would
   // trivially exhaust a per-IP limit on page navigation.
   if (isAuth) {
+    return intlResponse || NextResponse.next();
+  }
+
+  // Skip rate limiting for Next.js prefetch requests. These are fired in the
+  // background for every visible <Link> and would otherwise count against the
+  // per-IP limit even though the user never actively navigated.
+  const isPrefetch =
+    req.headers.get('Next-Router-Prefetch') === '1' ||
+    req.headers.get('purpose') === 'prefetch' ||
+    req.headers.get('x-purpose') === 'prefetch';
+
+  if (isPrefetch) {
     return intlResponse || NextResponse.next();
   }
 


### PR DESCRIPTION
## Problem

Anonymous visitors hit `Too Many Requests` (HTTP 429) when navigating the site at a normal-to-fast pace.

The page-navigation rate limiter in `src/middleware.ts` allowed only **10 requests per 10 seconds per IP**. Because Next.js prefetches every visible `<Link>` href in the background, a single page load can fire many requests against one IP, trivially exhausting the limit. The code already skipped this limit for authenticated users for exactly this reason — but anonymous visitors were not skipped.

## Changes

- **Raise the limit** from `slidingWindow(10, '10 s')` to `slidingWindow(50, '10 s')` to leave headroom for prefetch-inflated request counts.
- **Skip Next.js prefetch requests** so background prefetches no longer count against the per-IP limit. Covers both the App Router header (`Next-Router-Prefetch`) and the older `purpose` / `x-purpose` conventions.

Together these ensure anonymous users are throttled only on real navigations, with a realistic ceiling.

## Testing

Not compiled locally — `node_modules` is not installed in this environment, so `tsc` reports only "Cannot find module" errors for uninstalled dependencies. The change uses only the standard `req.headers.get()` API already used elsewhere in the file.

https://claude.ai/code/session_01AVvbPc8iEeJ52GrdZnrWc5

---
_Generated by [Claude Code](https://claude.ai/code/session_01AVvbPc8iEeJ52GrdZnrWc5)_