### PR TITLE
Fix review content width constraint on mobile

### DIFF
--- a/src/app/[locale]/reviews/[slug]/page.tsx
+++ b/src/app/[locale]/reviews/[slug]/page.tsx
@@ -170,7 +170,7 @@ export default function ReviewPage({ params }: { params: { slug: string } }) {
             </div>
           </div>
 
-          <div className="gc-prose max-w-prose">
+          <div className="gc-prose w-full">
             {getLocalizedContent(review, locale).split('\n').map((paragraph, index) => (
               paragraph.trim() && (
                 <p key={index} className="mb-6">


### PR DESCRIPTION
## Summary
Updated the review content container to use full width instead of a max-width constraint, improving readability and layout on smaller screens.

## Changes
- Replaced `max-w-prose` class with `w-full` on the review content container
  - This removes the maximum width restriction that was limiting content display
  - Allows the prose content to span the full available width of its parent container

## Details
The change affects the review page layout where the main review content is displayed. By removing the `max-w-prose` constraint and using `w-full` instead, the content will now be more responsive and better utilize available screen space, particularly on mobile and tablet devices where the prose max-width could create unnecessary constraints.

https://claude.ai/code/session_01B2TtyFRE51ZWFGAah9pcYu