### PR TITLE
Ignore local sqlite database files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,7 @@ logs/
 *.log
 
 /src/generated/prisma
+
+# local sqlite databases (never commit; may contain real or dev credentials)
+*.db
+*.db-journal


### PR DESCRIPTION
Prevents accidentally recommitting dev.db-style files, which previously leaked real admin credentials into git history.