### PR TITLE
Show 12 reviews per section on home to fill the grid row

### DIFF
--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -61,8 +61,8 @@ export default function Home() {
     const fetchReviews = async () => {
       try {
         const [animeRes, mangaRes] = await Promise.all([
-          fetch('/api/public/reviews?category=anime&limit=10'),
-          fetch('/api/public/reviews?category=manga&limit=10'),
+          fetch('/api/public/reviews?category=anime&limit=12'),
+          fetch('/api/public/reviews?category=manga&limit=12'),
         ]);
         setAnimeReviews(animeRes.ok ? await animeRes.json() : []);
         setMangaReviews(mangaRes.ok ? await mangaRes.json() : []);


### PR DESCRIPTION
The home grid is up to 4 columns on desktop, so 10 items left a ragged last row. Fetch 12 per category for clean 3- and 4-column rows.