### PR TITLE
Add drag-and-drop ordering for reviews in admin

### DIFF
--- a/.github/workflows/prisma-db-push.yml
+++ b/.github/workflows/prisma-db-push.yml
@@ -1,0 +1,28 @@
+name: Prisma DB Push
+
+# Manually-triggered workflow that syncs the Prisma schema to the database.
+# Run it from the repo's "Actions" tab -> "Prisma DB Push" -> "Run workflow".
+# Requires a repository secret named DATABASE_URL.
+on:
+  workflow_dispatch:
+
+jobs:
+  db-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Push Prisma schema to the database
+        run: npx prisma db push
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -28,6 +28,7 @@ model Review {
   category      String
   platform      String?
   rating        Float?
+  order         Int      @default(0)
   coverImage    String?
   imageData     String?
   imageMimeType String?
@@ -39,4 +40,6 @@ model Review {
   titleEn       String?
   titleEs       String?
   author        User     @relation(fields: [authorId], references: [id])
+
+  @@index([order])
 }

--- a/src/app/[locale]/admin/reviews/page.tsx
+++ b/src/app/[locale]/admin/reviews/page.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect } from 'react';
 import Link from 'next/link';
 import { useLocale } from 'next-intl';
-import { PlusIcon, PencilIcon, TrashIcon } from '@heroicons/react/24/outline';
+import { PlusIcon, PencilIcon, TrashIcon, Bars3Icon } from '@heroicons/react/24/outline';
 import { getLocalizedTitle } from '@/lib/utils';
 
 interface Review {
@@ -16,6 +16,7 @@ interface Review {
   youtubeUrl?: string;
   rating?: number;
   status: string;
+  order?: number;
   createdAt: string;
   updatedAt: string;
   content?: string;
@@ -33,6 +34,9 @@ export default function ReviewsPage() {
   const [searchTerm, setSearchTerm] = useState('');
   const [categoryFilter, setCategoryFilter] = useState('');
   const [statusFilter, setStatusFilter] = useState('');
+  const [draggingIndex, setDraggingIndex] = useState<number | null>(null);
+  const [dragOverIndex, setDragOverIndex] = useState<number | null>(null);
+  const [savingOrder, setSavingOrder] = useState(false);
   const locale = useLocale();
 
   useEffect(() => {
@@ -90,14 +94,85 @@ export default function ReviewsPage() {
     }
   };
 
+  const filtersActive = Boolean(searchTerm || categoryFilter || statusFilter);
+
   const filteredReviews = reviews.filter(review => {
     const localizedTitle = getLocalizedTitle(review, locale);
     const matchesSearch = localizedTitle.toLowerCase().includes(searchTerm.toLowerCase());
     const matchesCategory = !categoryFilter || review.category.toLowerCase().includes(categoryFilter.toLowerCase());
     const matchesStatus = !statusFilter || review.status.toLowerCase() === statusFilter.toLowerCase();
-    
+
     return matchesSearch && matchesCategory && matchesStatus;
   });
+
+  // Persist a freshly reordered list to the server. Updates the UI optimistically
+  // and reverts if the request fails. The order is global and is reflected on the
+  // public site (home, category pages and the all-reviews page).
+  const persistOrder = async (ordered: Review[]) => {
+    const previous = reviews;
+    setReviews(ordered);
+    setSavingOrder(true);
+    try {
+      const csrfResponse = await fetch('/api/csrf', { credentials: 'include' });
+      if (!csrfResponse.ok) {
+        throw new Error('Could not verify session');
+      }
+      const { token: csrfToken } = await csrfResponse.json();
+
+      const response = await fetch('/api/reviews/reorder', {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-CSRF-Token': csrfToken,
+        },
+        credentials: 'include',
+        body: JSON.stringify({ ids: ordered.map((review) => review.id) }),
+      });
+
+      if (!response.ok) {
+        const error = await response.json().catch(() => ({}));
+        throw new Error(error.error || 'Failed to save order');
+      }
+    } catch (error) {
+      console.error('Error saving review order:', error);
+      setReviews(previous);
+      alert('Failed to save the new order. Please try again.');
+    } finally {
+      setSavingOrder(false);
+    }
+  };
+
+  const handleDragStart = (index: number) => {
+    if (filtersActive) return;
+    setDraggingIndex(index);
+  };
+
+  const handleDragOver = (index: number, e: React.DragEvent) => {
+    if (filtersActive || draggingIndex === null) return;
+    e.preventDefault();
+    setDragOverIndex(index);
+  };
+
+  const handleDrop = (index: number) => {
+    if (filtersActive || draggingIndex === null || draggingIndex === index) {
+      setDraggingIndex(null);
+      setDragOverIndex(null);
+      return;
+    }
+
+    const reordered = [...reviews];
+    const [moved] = reordered.splice(draggingIndex, 1);
+    reordered.splice(index, 0, moved);
+
+    setDraggingIndex(null);
+    setDragOverIndex(null);
+    persistOrder(reordered);
+  };
+
+  const handleDragEnd = () => {
+    setDraggingIndex(null);
+    setDragOverIndex(null);
+  };
 
   const formatDate = (dateString: string) => {
     return new Date(dateString).toLocaleDateString();
@@ -159,11 +234,27 @@ export default function ReviewsPage() {
         </select>
       </div>
 
+      {/* Reorder hint */}
+      <div className="text-sm text-gray-400">
+        {filtersActive ? (
+          <span className="text-yellow-400/80">
+            Clear search and filters to drag &amp; drop reviews into a new order.
+          </span>
+        ) : (
+          <span>
+            Drag the <Bars3Icon className="inline w-4 h-4 -mt-0.5" /> handle to reorder reviews.
+            This order is reflected on the home page, category pages and the all-reviews page.
+            {savingOrder && <span className="ml-2 text-blue-400">Saving…</span>}
+          </span>
+        )}
+      </div>
+
       {/* Reviews Table */}
       <div className="bg-[#1a1a1a] rounded-lg border border-gray-800">
         <table className="w-full">
           <thead>
             <tr className="border-b border-gray-800">
+              <th className="px-3 py-4 text-left text-sm font-medium text-gray-400 w-10"></th>
               <th className="px-6 py-4 text-left text-sm font-medium text-gray-400">Title</th>
               <th className="px-6 py-4 text-left text-sm font-medium text-gray-400">Category</th>
               <th className="px-6 py-4 text-left text-sm font-medium text-gray-400">Titles</th>
@@ -176,8 +267,34 @@ export default function ReviewsPage() {
           </thead>
           <tbody className="divide-y divide-gray-800">
             {filteredReviews.length > 0 ? (
-              filteredReviews.map((review) => (
-                <tr key={review.id} className="hover:bg-[#2d2d2d] transition-colors">
+              filteredReviews.map((review, index) => (
+                <tr
+                  key={review.id}
+                  onDragOver={(e) => handleDragOver(index, e)}
+                  onDrop={() => handleDrop(index)}
+                  className={`transition-colors ${
+                    draggingIndex === index ? 'opacity-50' : ''
+                  } ${
+                    dragOverIndex === index && draggingIndex !== index
+                      ? 'border-t-2 border-blue-500'
+                      : ''
+                  } hover:bg-[#2d2d2d]`}
+                >
+                  <td className="px-3 py-4">
+                    <span
+                      draggable={!filtersActive}
+                      onDragStart={() => handleDragStart(index)}
+                      onDragEnd={handleDragEnd}
+                      title={filtersActive ? 'Clear filters to reorder' : 'Drag to reorder'}
+                      className={`inline-flex ${
+                        filtersActive
+                          ? 'text-gray-700 cursor-not-allowed'
+                          : 'text-gray-500 hover:text-white cursor-grab active:cursor-grabbing'
+                      }`}
+                    >
+                      <Bars3Icon className="w-5 h-5" />
+                    </span>
+                  </td>
                   <td className="px-6 py-4">
                     <div>
                       <div className="text-white font-medium">{getLocalizedTitle(review, locale)}</div>
@@ -244,7 +361,7 @@ export default function ReviewsPage() {
               ))
             ) : (
               <tr>
-                <td colSpan={8} className="px-6 py-12 text-center">
+                <td colSpan={9} className="px-6 py-12 text-center">
                   <div className="text-gray-400">
                     <div className="text-lg font-medium mb-2">No reviews found</div>
                     <div className="text-sm">

--- a/src/app/[locale]/anime-manga/page.tsx
+++ b/src/app/[locale]/anime-manga/page.tsx
@@ -7,6 +7,7 @@ import ReviewGrid from '@/components/ReviewGrid';
 interface Review {
   id: string;
   title: string;
+  order?: number;
   category: string;
   coverImage?: string;
   imageData?: string;
@@ -47,9 +48,14 @@ export default function AnimeMangaPage() {
       const animeData = animeResponse.ok ? await animeResponse.json() : [];
       const mangaData = mangaResponse.ok ? await mangaResponse.json() : [];
 
-      const allReviews = [...animeData, ...mangaData].sort((a, b) => 
-        new Date(b.date).getTime() - new Date(a.date).getTime()
-      );
+      // Merge anime + manga and honour the admin's manual ordering
+      // (lower `order` first), falling back to newest-first by date.
+      const allReviews = [...animeData, ...mangaData].sort((a, b) => {
+        const orderA = a.order ?? 0;
+        const orderB = b.order ?? 0;
+        if (orderA !== orderB) return orderA - orderB;
+        return new Date(b.date).getTime() - new Date(a.date).getTime();
+      });
 
       setReviews(allReviews);
     } catch (error) {

--- a/src/app/api/public/reviews/route.ts
+++ b/src/app/api/public/reviews/route.ts
@@ -36,13 +36,14 @@ export async function GET(request: NextRequest) {
         slug: true,
         rating: true,
         status: true,
+        order: true,
         createdAt: true,
         updatedAt: true,
         author: {
           select: { name: true },
         },
       },
-      orderBy: { createdAt: 'desc' },
+      orderBy: [{ order: 'asc' }, { createdAt: 'desc' }],
       ...(take !== undefined ? { take } : {}),
     });
 
@@ -69,6 +70,7 @@ export async function GET(request: NextRequest) {
       slug: review.slug,
       rating: review.rating,
       status: review.status,
+      order: review.order,
       authorName: review.author.name,
     }));
 

--- a/src/app/api/reviews/reorder/route.ts
+++ b/src/app/api/reviews/reorder/route.ts
@@ -1,0 +1,76 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '../../auth/[...nextauth]/authOptions';
+import { csrfMiddleware } from '@/lib/csrf';
+import { rateLimitMiddleware } from '@/lib/rateLimit';
+import { prisma } from '@/lib/prisma';
+import { logger } from '@/lib/logger';
+
+// PATCH — persist a new display order for reviews.
+// Accepts an ordered list of review IDs; each review's `order` is set to its
+// index in the list. The order is global and is reflected everywhere reviews
+// are listed (home, category pages and the all-reviews page).
+export async function PATCH(request: NextRequest) {
+  let session;
+
+  try {
+    const rateLimitResult = await rateLimitMiddleware(request);
+    if (rateLimitResult) {
+      logger.warn('Rate limit exceeded', { ip: request.ip, path: request.nextUrl.pathname });
+      return rateLimitResult;
+    }
+
+    if (process.env.NODE_ENV === 'production') {
+      const csrfResult = await csrfMiddleware(request);
+      if (csrfResult) {
+        logger.warn('CSRF validation failed', { ip: request.ip, path: request.nextUrl.pathname });
+        return csrfResult;
+      }
+    }
+
+    session = await getServerSession(authOptions);
+    if (!session?.user?.email) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+    if (session.user.role !== 'admin') {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+    }
+
+    const body = await request.json();
+    const ids = body?.ids;
+
+    if (!Array.isArray(ids) || ids.length === 0 || !ids.every((id) => typeof id === 'string')) {
+      return NextResponse.json(
+        { error: 'Expected a non-empty array of review IDs' },
+        { status: 400 }
+      );
+    }
+
+    // Guard against duplicate IDs sneaking in.
+    if (new Set(ids).size !== ids.length) {
+      return NextResponse.json({ error: 'Duplicate review IDs' }, { status: 400 });
+    }
+
+    logger.info('Reordering reviews', { count: ids.length });
+
+    await prisma.$transaction(
+      ids.map((id, index) =>
+        prisma.review.update({
+          where: { id },
+          data: { order: index },
+        })
+      )
+    );
+
+    logger.info('Reviews reordered successfully', { count: ids.length });
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    logger.error('Error reordering reviews', error as Error, { userEmail: session?.user?.email });
+
+    if (error instanceof Error && error.message.includes('Record to update not found')) {
+      return NextResponse.json({ error: 'One or more reviews not found' }, { status: 404 });
+    }
+
+    return NextResponse.json({ error: 'Failed to reorder reviews' }, { status: 500 });
+  }
+}

--- a/src/app/api/reviews/route.ts
+++ b/src/app/api/reviews/route.ts
@@ -41,6 +41,7 @@ export async function GET(request: NextRequest) {
         youtubeUrl: true,
         rating: true,
         status: true,
+        order: true,
         createdAt: true,
         updatedAt: true,
         authorId: true,
@@ -51,7 +52,7 @@ export async function GET(request: NextRequest) {
           },
         },
       },
-      orderBy: { createdAt: 'desc' },
+      orderBy: [{ order: 'asc' }, { createdAt: 'desc' }],
     });
 
     const hasContentFlags = await prisma.$queryRaw`
@@ -156,10 +157,15 @@ export async function POST(request: NextRequest) {
       }
     }
 
+    // Place new reviews at the top of the manual ordering (lowest `order`).
+    const { _min } = await prisma.review.aggregate({ _min: { order: true } });
+    const newOrder = (_min.order ?? 0) - 1;
+
     logger.info('Creating new review', { title, category, authorId: user.id });
 
     const review = await prisma.review.create({
       data: {
+        order: newOrder,
         title,
         titleEs: titleEs ?? null,
         titleEn: titleEn ?? null,

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -44,7 +44,7 @@ export async function GET(request: NextRequest) {
           select: { name: true },
         },
       },
-      orderBy: { createdAt: 'desc' },
+      orderBy: [{ order: 'asc' }, { createdAt: 'desc' }],
       take: SEARCH_LIMIT,
     });
 


### PR DESCRIPTION
Introduce a global manual `order` field on Review so reviews can be reordered from the admin panel and have that order reflected across the public site.

- schema: add `order Int @default(0)` (+ index) to Review
- api: new PATCH /api/reviews/reorder (admin-only, CSRF) persists order from an ordered list of IDs
- api: list endpoints (admin, public, search) now order by [order asc, createdAt desc]; new reviews are inserted at the top
- admin: drag-and-drop the row handle to reorder, with optimistic save and revert on failure (disabled while filters are active)
- anime-manga page: merge anime + manga honouring the manual order


Claude-Session: https://claude.ai/code/session_01UA7ErycrvpwHr6juKpkwQJ