### PR TITLE
Fix review reorder hitting Accelerate 5MB response limit

### DIFF
--- a/src/app/api/reviews/reorder/route.ts
+++ b/src/app/api/reviews/reorder/route.ts
@@ -53,9 +53,13 @@ export async function PATCH(request: NextRequest) {
 
     logger.info('Reordering reviews', { count: ids.length });
 
+    // Use updateMany (not update) so each statement returns only a row count
+    // rather than the full review record. update() would echo back every
+    // column — including the large base64 `imageData` blob — which overflows
+    // Prisma Accelerate's 5MB response limit (P6009) across the batch.
     await prisma.$transaction(
       ids.map((id, index) =>
-        prisma.review.update({
+        prisma.review.updateMany({
           where: { id },
           data: { order: index },
         })


### PR DESCRIPTION
## Problem

Reordering reviews failed with Prisma Accelerate error **P6009** ("response size exceeded the maximum of 5MB"). The reorder transaction ran `prisma.review.update()` per review, and `update()` echoes back the full row — including each review's large base64 `imageData` blob — so the batched response overflowed Accelerate's 5MB limit.

## Fix

Use `prisma.review.updateMany()` instead, which returns only a row count rather than the record contents. No image data is fetched, so the response stays tiny.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UA7ErycrvpwHr6juKpkwQJ)_