### PR TITLE
Hide empty homepage sections and redundant filter buttons

### DIFF
--- a/src/app/[locale]/anime-manga/page.tsx
+++ b/src/app/[locale]/anime-manga/page.tsx
@@ -92,6 +92,12 @@ export default function AnimeMangaPage() {
         : 'text-ink-700 bg-paper-200 hover:bg-paper-300'
     }`;
 
+  // Only offer the filter buttons when there is something to filter between —
+  // i.e. both anime and manga reviews exist.
+  const hasAnime = reviews.some(review => review.category === 'anime');
+  const hasManga = reviews.some(review => review.category === 'manga');
+  const showFilters = hasAnime && hasManga;
+
   return (
     <div className="space-y-8">
       <div>
@@ -100,17 +106,19 @@ export default function AnimeMangaPage() {
         <p className="mt-2 font-body text-ink-600">{t('animeMangaDescription')}</p>
       </div>
 
-      <div className="flex flex-wrap gap-3">
-        <button onClick={() => handleFilterChange('all')} className={filterBtn('all')}>
-          {t('filterAll')}
-        </button>
-        <button onClick={() => handleFilterChange('anime')} className={filterBtn('anime')}>
-          {t('filterAnime')}
-        </button>
-        <button onClick={() => handleFilterChange('manga')} className={filterBtn('manga')}>
-          {t('filterManga')}
-        </button>
-      </div>
+      {showFilters && (
+        <div className="flex flex-wrap gap-3">
+          <button onClick={() => handleFilterChange('all')} className={filterBtn('all')}>
+            {t('filterAll')}
+          </button>
+          <button onClick={() => handleFilterChange('anime')} className={filterBtn('anime')}>
+            {t('filterAnime')}
+          </button>
+          <button onClick={() => handleFilterChange('manga')} className={filterBtn('manga')}>
+            {t('filterManga')}
+          </button>
+        </div>
+      )}
 
       {filteredReviews.length > 0 ? (
         <ReviewGrid reviews={filteredReviews} />

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -57,6 +57,11 @@ export default function Home() {
   const tCommon = useTranslations('common');
   const locale = useLocale();
 
+  // While loading we show skeletons for both sections; once loaded, only show
+  // a section if it actually has reviews.
+  const showAnime = loading || animeReviews.length > 0;
+  const showManga = loading || mangaReviews.length > 0;
+
   useEffect(() => {
     const fetchReviews = async () => {
       try {
@@ -110,6 +115,7 @@ export default function Home() {
       <div className="space-y-14">
 
         {/* Anime — persimmon accent */}
+        {showAnime && (
         <section aria-label="Anime">
           <div className="flex items-end justify-between mb-7">
             <div className="flex items-center gap-3">
@@ -134,18 +140,16 @@ export default function Home() {
 
           {loading ? (
             <SkeletonGrid />
-          ) : animeReviews.length > 0 ? (
-            <ReviewGrid reviews={animeReviews} />
           ) : (
-            <div className="text-center text-ink-500 py-10 bg-paper-50 rounded-xl border border-border">
-              {t('noAnimePosts')}
-            </div>
+            <ReviewGrid reviews={animeReviews} />
           )}
         </section>
+        )}
 
-        <div className="border-t border-divider" />
+        {showAnime && showManga && <div className="border-t border-divider" />}
 
         {/* Manga — indigo accent */}
+        {showManga && (
         <section aria-label="Manga">
           <div className="flex items-end justify-between mb-7">
             <div className="flex items-center gap-3">
@@ -170,14 +174,11 @@ export default function Home() {
 
           {loading ? (
             <SkeletonGrid />
-          ) : mangaReviews.length > 0 ? (
-            <ReviewGrid reviews={mangaReviews} />
           ) : (
-            <div className="text-center text-ink-500 py-10 bg-paper-50 rounded-xl border border-border">
-              {t('noMangaPosts')}
-            </div>
+            <ReviewGrid reviews={mangaReviews} />
           )}
         </section>
+        )}
 
       </div>
     </div>


### PR DESCRIPTION
On the homepage, only render the Anime/Manga sections (and the divider between them) when they actually contain reviews. On the anime-manga page, only show the All/Anime/Manga filter buttons when both categories have reviews, since filtering is pointless otherwise.


Claude-Session: https://claude.ai/code/session_01QEqyrbxatWCjMMGTWyjcZ4