### PR TITLE
Add editable home banner + hide empty homepage sections/filters

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -43,3 +43,25 @@ model Review {
 
   @@index([order])
 }
+
+// Singleton record holding the editable homepage hero banner.
+// There is only ever one row, keyed by a fixed id ("home").
+model HomeBanner {
+  id               String   @id @default("home")
+  kickerEs         String?
+  kickerEn         String?
+  titleEs          String?
+  titleEn          String?
+  subtitleEs       String?
+  subtitleEn       String?
+  primaryLabelEs   String?
+  primaryLabelEn   String?
+  primaryLink      String?
+  secondaryLabelEs String?
+  secondaryLabelEn String?
+  secondaryLink    String?
+  backgroundImage  String?
+  imageData        String?
+  imageMimeType    String?
+  updatedAt        DateTime @updatedAt
+}

--- a/src/app/[locale]/admin/banner/page.tsx
+++ b/src/app/[locale]/admin/banner/page.tsx
@@ -1,0 +1,447 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import Link from 'next/link';
+import { useLocale } from 'next-intl';
+import { ArrowLeftIcon } from '@heroicons/react/24/outline';
+
+interface BannerFormData {
+  kickerEs: string;
+  kickerEn: string;
+  titleEs: string;
+  titleEn: string;
+  subtitleEs: string;
+  subtitleEn: string;
+  primaryLabelEs: string;
+  primaryLabelEn: string;
+  primaryLink: string;
+  secondaryLabelEs: string;
+  secondaryLabelEn: string;
+  secondaryLink: string;
+  backgroundImage: string;
+  imageData?: string;
+  imageMimeType?: string;
+}
+
+const emptyForm: BannerFormData = {
+  kickerEs: '',
+  kickerEn: '',
+  titleEs: '',
+  titleEn: '',
+  subtitleEs: '',
+  subtitleEn: '',
+  primaryLabelEs: '',
+  primaryLabelEn: '',
+  primaryLink: '',
+  secondaryLabelEs: '',
+  secondaryLabelEn: '',
+  secondaryLink: '',
+  backgroundImage: '',
+};
+
+const inputClass =
+  'w-full px-4 py-2 bg-[#1a1a1a] border border-gray-800 rounded-lg text-white placeholder-gray-400 focus:outline-none focus:border-blue-500';
+const labelClass = 'block text-sm font-medium text-gray-300';
+
+export default function BannerEditor() {
+  const [formData, setFormData] = useState<BannerFormData>(emptyForm);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [uploading, setUploading] = useState(false);
+  const [savedMessage, setSavedMessage] = useState('');
+  const [activeLang, setActiveLang] = useState<'es' | 'en'>('es');
+  const [useImageUpload, setUseImageUpload] = useState(false);
+  const [imagePreview, setImagePreview] = useState<string | null>(null);
+  const locale = useLocale();
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const res = await fetch('/api/home-banner', { credentials: 'include' });
+        if (res.ok) {
+          const data = await res.json();
+          setFormData({ ...emptyForm, ...sanitize(data) });
+          if (data.imageData) {
+            setUseImageUpload(true);
+            setImagePreview(`data:${data.imageMimeType};base64,${data.imageData}`);
+          } else if (data.backgroundImage) {
+            setUseImageUpload(false);
+            setImagePreview(data.backgroundImage);
+          }
+        }
+      } catch (error) {
+        console.error('Error loading banner:', error);
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
+  }, []);
+
+  // Replace nulls from the API with empty strings for controlled inputs.
+  const sanitize = (data: Record<string, unknown>): Partial<BannerFormData> => {
+    const out: Record<string, string> = {};
+    for (const key of Object.keys(emptyForm) as (keyof BannerFormData)[]) {
+      const value = data[key];
+      out[key] = typeof value === 'string' ? value : '';
+    }
+    return out as Partial<BannerFormData>;
+  };
+
+  const handleChange = (
+    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+  ) => {
+    const { name, value } = e.target;
+    setFormData((prev) => ({ ...prev, [name]: value }));
+    if (name === 'backgroundImage' && !useImageUpload) {
+      setImagePreview(value || null);
+    }
+  };
+
+  const getCsrfToken = async () => {
+    const res = await fetch('/api/csrf', { credentials: 'include' });
+    if (!res.ok) throw new Error('Failed to get CSRF token. Please make sure you are logged in.');
+    const { token } = await res.json();
+    return token as string;
+  };
+
+  const handleImageModeChange = (useUpload: boolean) => {
+    setUseImageUpload(useUpload);
+    if (useUpload) {
+      setFormData((prev) => ({ ...prev, backgroundImage: '' }));
+      setImagePreview(formData.imageData ? `data:${formData.imageMimeType};base64,${formData.imageData}` : null);
+    } else {
+      setFormData((prev) => ({ ...prev, imageData: undefined, imageMimeType: undefined }));
+      setImagePreview(formData.backgroundImage || null);
+    }
+  };
+
+  const handleImageUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    setUploading(true);
+    try {
+      const body = new FormData();
+      body.append('image', file);
+      const csrfToken = await getCsrfToken();
+
+      const res = await fetch('/api/upload', {
+        method: 'POST',
+        headers: { 'X-CSRF-Token': csrfToken, Accept: 'application/json' },
+        body,
+      });
+
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        throw new Error(err.error || err.details || `Failed to upload image (${res.status})`);
+      }
+
+      const result = await res.json();
+      setFormData((prev) => ({
+        ...prev,
+        imageData: result.imageData,
+        imageMimeType: result.mimeType,
+        backgroundImage: '',
+      }));
+      setImagePreview(`data:${result.mimeType};base64,${result.imageData}`);
+    } catch (error) {
+      alert(error instanceof Error ? error.message : 'Failed to upload image');
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  const clearImage = () => {
+    setFormData((prev) => ({
+      ...prev,
+      imageData: undefined,
+      imageMimeType: undefined,
+      backgroundImage: '',
+    }));
+    setImagePreview(null);
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSaving(true);
+    setSavedMessage('');
+    try {
+      const csrfToken = await getCsrfToken();
+      const res = await fetch('/api/home-banner', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': csrfToken },
+        body: JSON.stringify(formData),
+        credentials: 'include',
+      });
+
+      if (res.ok) {
+        setSavedMessage('Banner saved successfully.');
+      } else {
+        const err = await res.json().catch(() => ({}));
+        alert(`Failed to save banner: ${err.error || res.status}`);
+      }
+    } catch (error) {
+      alert(error instanceof Error ? error.message : 'Failed to save banner');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="flex justify-center items-center h-64">
+        <div className="text-white">Loading banner...</div>
+      </div>
+    );
+  }
+
+  const langField = (
+    base: 'kicker' | 'title' | 'subtitle' | 'primaryLabel' | 'secondaryLabel'
+  ) => `${base}${activeLang === 'es' ? 'Es' : 'En'}` as keyof BannerFormData;
+
+  return (
+    <div className="space-y-8">
+      <div className="space-y-3">
+        <Link
+          href={`/${locale}/admin`}
+          className="inline-flex items-center text-blue-400 hover:text-blue-300 text-sm font-medium"
+        >
+          <ArrowLeftIcon className="w-4 h-4 mr-2" />
+          Back to Dashboard
+        </Link>
+        <h1 className="text-3xl font-bold text-white">Home Banner</h1>
+        <p className="text-gray-400 text-sm">
+          Customise the hero banner shown at the top of the homepage. Empty fields fall back to the
+          site&apos;s default text.
+        </p>
+      </div>
+
+      <form onSubmit={handleSubmit} className="space-y-8">
+        {/* Language tabs */}
+        <div className="flex space-x-1 bg-gray-800 p-1 rounded-lg max-w-sm">
+          <button
+            type="button"
+            onClick={() => setActiveLang('es')}
+            className={`flex-1 px-4 py-2 text-sm font-medium rounded-md transition-colors ${
+              activeLang === 'es' ? 'bg-blue-500 text-white' : 'text-gray-300 hover:text-white hover:bg-gray-700'
+            }`}
+          >
+            🇪🇸 Español
+          </button>
+          <button
+            type="button"
+            onClick={() => setActiveLang('en')}
+            className={`flex-1 px-4 py-2 text-sm font-medium rounded-md transition-colors ${
+              activeLang === 'en' ? 'bg-blue-500 text-white' : 'text-gray-300 hover:text-white hover:bg-gray-700'
+            }`}
+          >
+            🇺🇸 English
+          </button>
+        </div>
+
+        {/* Text fields (per language) */}
+        <div className="space-y-4 bg-[#1a1a1a] border border-gray-800 rounded-lg p-6">
+          <h2 className="text-lg font-semibold text-white">
+            Text ({activeLang === 'es' ? 'Español' : 'English'})
+          </h2>
+
+          <div className="space-y-2">
+            <label htmlFor={langField('kicker')} className={labelClass}>Kicker (small text above title)</label>
+            <input
+              type="text"
+              id={langField('kicker')}
+              name={langField('kicker')}
+              value={formData[langField('kicker')] as string}
+              onChange={handleChange}
+              placeholder="e.g. Slow reads · Considered takes"
+              className={inputClass}
+            />
+          </div>
+
+          <div className="space-y-2">
+            <label htmlFor={langField('title')} className={labelClass}>Title</label>
+            <input
+              type="text"
+              id={langField('title')}
+              name={langField('title')}
+              value={formData[langField('title')] as string}
+              onChange={handleChange}
+              placeholder="e.g. Essays on anime, manga and video games"
+              className={inputClass}
+            />
+          </div>
+
+          <div className="space-y-2">
+            <label htmlFor={langField('subtitle')} className={labelClass}>Subtitle</label>
+            <textarea
+              id={langField('subtitle')}
+              name={langField('subtitle')}
+              value={formData[langField('subtitle')] as string}
+              onChange={handleChange}
+              rows={3}
+              placeholder="Short description shown under the title"
+              className={inputClass}
+            />
+          </div>
+        </div>
+
+        {/* Buttons */}
+        <div className="space-y-6 bg-[#1a1a1a] border border-gray-800 rounded-lg p-6">
+          <h2 className="text-lg font-semibold text-white">Buttons</h2>
+
+          {/* Primary button */}
+          <div className="space-y-3">
+            <h3 className="text-sm font-semibold text-gray-300">Primary button</h3>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <label htmlFor={langField('primaryLabel')} className={labelClass}>
+                  Label ({activeLang === 'es' ? 'Español' : 'English'})
+                </label>
+                <input
+                  type="text"
+                  id={langField('primaryLabel')}
+                  name={langField('primaryLabel')}
+                  value={formData[langField('primaryLabel')] as string}
+                  onChange={handleChange}
+                  placeholder="e.g. View all reviews"
+                  className={inputClass}
+                />
+              </div>
+              <div className="space-y-2">
+                <label htmlFor="primaryLink" className={labelClass}>Link</label>
+                <input
+                  type="text"
+                  id="primaryLink"
+                  name="primaryLink"
+                  value={formData.primaryLink}
+                  onChange={handleChange}
+                  placeholder="e.g. anime-manga or https://..."
+                  className={inputClass}
+                />
+              </div>
+            </div>
+          </div>
+
+          {/* Secondary button */}
+          <div className="space-y-3">
+            <h3 className="text-sm font-semibold text-gray-300">Secondary button (optional)</h3>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <label htmlFor={langField('secondaryLabel')} className={labelClass}>
+                  Label ({activeLang === 'es' ? 'Español' : 'English'})
+                </label>
+                <input
+                  type="text"
+                  id={langField('secondaryLabel')}
+                  name={langField('secondaryLabel')}
+                  value={formData[langField('secondaryLabel')] as string}
+                  onChange={handleChange}
+                  placeholder="Leave empty to hide this button"
+                  className={inputClass}
+                />
+              </div>
+              <div className="space-y-2">
+                <label htmlFor="secondaryLink" className={labelClass}>Link</label>
+                <input
+                  type="text"
+                  id="secondaryLink"
+                  name="secondaryLink"
+                  value={formData.secondaryLink}
+                  onChange={handleChange}
+                  placeholder="e.g. video-games or https://..."
+                  className={inputClass}
+                />
+              </div>
+            </div>
+          </div>
+          <p className="text-xs text-gray-500">
+            Links can be an internal path (e.g. <code>anime-manga</code>) or a full URL starting with
+            http(s). Internal paths are shown in the visitor&apos;s language automatically.
+          </p>
+        </div>
+
+        {/* Background image */}
+        <div className="space-y-4 bg-[#1a1a1a] border border-gray-800 rounded-lg p-6">
+          <h2 className="text-lg font-semibold text-white">Background image (optional)</h2>
+          <p className="text-xs text-gray-500">
+            Leave empty to keep the default gradient background. A dark overlay is added automatically
+            for text legibility.
+          </p>
+
+          <div className="flex space-x-4">
+            <button
+              type="button"
+              onClick={() => handleImageModeChange(true)}
+              className={`px-4 py-2 rounded-lg text-sm font-medium transition-colors ${
+                useImageUpload ? 'bg-blue-500 text-white' : 'bg-gray-700 text-gray-300 hover:bg-gray-600'
+              }`}
+            >
+              Upload Image
+            </button>
+            <button
+              type="button"
+              onClick={() => handleImageModeChange(false)}
+              className={`px-4 py-2 rounded-lg text-sm font-medium transition-colors ${
+                !useImageUpload ? 'bg-blue-500 text-white' : 'bg-gray-700 text-gray-300 hover:bg-gray-600'
+              }`}
+            >
+              Image URL
+            </button>
+          </div>
+
+          {useImageUpload ? (
+            <div className="space-y-2">
+              <input
+                type="file"
+                accept="image/*"
+                onChange={handleImageUpload}
+                disabled={uploading}
+                className="w-full px-4 py-2 bg-[#1a1a1a] border border-gray-800 rounded-lg text-white file:mr-4 file:py-2 file:px-4 file:rounded-lg file:border-0 file:text-sm file:font-medium file:bg-blue-500 file:text-white hover:file:bg-blue-600 disabled:opacity-50"
+              />
+              {uploading && <div className="text-blue-400 text-sm">Uploading image...</div>}
+            </div>
+          ) : (
+            <input
+              type="url"
+              id="backgroundImage"
+              name="backgroundImage"
+              value={formData.backgroundImage}
+              onChange={handleChange}
+              placeholder="https://..."
+              className={inputClass}
+            />
+          )}
+
+          {imagePreview && (
+            <div className="space-y-2">
+              <div className="relative overflow-hidden rounded-lg border border-gray-700 max-w-md">
+                <img src={imagePreview} alt="Background preview" className="w-full h-48 object-cover" />
+                <div className="absolute inset-0 bg-[#231a14]/70" />
+              </div>
+              <button
+                type="button"
+                onClick={clearImage}
+                className="text-sm text-red-400 hover:text-red-300"
+              >
+                Remove background image
+              </button>
+            </div>
+          )}
+        </div>
+
+        {/* Actions */}
+        <div className="flex items-center justify-end gap-4">
+          {savedMessage && <span className="text-green-400 text-sm">{savedMessage}</span>}
+          <button
+            type="submit"
+            disabled={saving}
+            className="px-5 py-2 bg-blue-500 text-white rounded-lg hover:bg-blue-600 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {saving ? 'Saving...' : 'Save Banner'}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/src/app/[locale]/admin/layout.tsx
+++ b/src/app/[locale]/admin/layout.tsx
@@ -4,9 +4,10 @@ import Link from 'next/link';
 import { useSession } from 'next-auth/react';
 import { redirect, usePathname } from 'next/navigation';
 import { useLocale } from 'next-intl';
-import { 
-  HomeIcon, 
-  DocumentTextIcon
+import {
+  HomeIcon,
+  DocumentTextIcon,
+  PhotoIcon
 } from '@heroicons/react/24/outline';
 
 export default function AdminLayout({
@@ -21,6 +22,7 @@ export default function AdminLayout({
   const sidebarItems = [
     { name: 'Dashboard', href: `/${locale}/admin`, icon: HomeIcon },
     { name: 'All Reviews', href: `/${locale}/admin/reviews`, icon: DocumentTextIcon },
+    { name: 'Home Banner', href: `/${locale}/admin/banner`, icon: PhotoIcon },
   ];
   
   // Don't apply authentication check to login page

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -49,9 +49,45 @@ function SkeletonGrid() {
   );
 }
 
+interface Banner {
+  kickerEs?: string | null;
+  kickerEn?: string | null;
+  titleEs?: string | null;
+  titleEn?: string | null;
+  subtitleEs?: string | null;
+  subtitleEn?: string | null;
+  primaryLabelEs?: string | null;
+  primaryLabelEn?: string | null;
+  primaryLink?: string | null;
+  secondaryLabelEs?: string | null;
+  secondaryLabelEn?: string | null;
+  secondaryLink?: string | null;
+  backgroundUrl?: string | null;
+}
+
+function firstNonEmpty(...vals: (string | null | undefined)[]): string {
+  return vals.find((v) => v && v.trim() !== '')?.trim() ?? '';
+}
+
+// Resolve an admin-entered link. Absolute http(s) links are returned as-is;
+// anything else is treated as an internal path and given a locale prefix.
+function resolveHref(link: string | null | undefined, locale: string, fallback: string): string {
+  if (!link || !link.trim()) return fallback;
+  const value = link.trim();
+  if (/^https?:\/\//i.test(value)) return value;
+  const path = value.startsWith('/') ? value : `/${value}`;
+  if (path === `/${locale}` || path.startsWith(`/${locale}/`)) return path;
+  return `/${locale}${path}`;
+}
+
+function isExternal(link: string | null | undefined): boolean {
+  return /^https?:\/\//i.test(link?.trim() ?? '');
+}
+
 export default function Home() {
   const [animeReviews, setAnimeReviews] = useState<Review[]>([]);
   const [mangaReviews, setMangaReviews] = useState<Review[]>([]);
+  const [banner, setBanner] = useState<Banner>({});
   const [loading, setLoading] = useState(true);
   const t = useTranslations('home');
   const tCommon = useTranslations('common');
@@ -65,12 +101,14 @@ export default function Home() {
   useEffect(() => {
     const fetchReviews = async () => {
       try {
-        const [animeRes, mangaRes] = await Promise.all([
+        const [animeRes, mangaRes, bannerRes] = await Promise.all([
           fetch('/api/public/reviews?category=anime&limit=12'),
           fetch('/api/public/reviews?category=manga&limit=12'),
+          fetch('/api/public/home-banner'),
         ]);
         setAnimeReviews(animeRes.ok ? await animeRes.json() : []);
         setMangaReviews(mangaRes.ok ? await mangaRes.json() : []);
+        if (bannerRes.ok) setBanner(await bannerRes.json());
       } catch (error) {
         console.error('Error fetching reviews:', error);
       } finally {
@@ -80,33 +118,94 @@ export default function Home() {
     fetchReviews();
   }, []);
 
+  // Pick the field for the current locale, falling back to the other
+  // language and finally to the translated default.
+  const pickText = (es?: string | null, en?: string | null, fallback = '') =>
+    firstNonEmpty(locale === 'en' ? en : es, locale === 'en' ? es : en) || fallback;
+
+  const kicker = pickText(banner.kickerEs, banner.kickerEn, t('heroKicker'));
+  const heroTitle = pickText(banner.titleEs, banner.titleEn, t('heroTitle'));
+  const subtitle = pickText(banner.subtitleEs, banner.subtitleEn, t('subtitle'));
+  const primaryLabel = pickText(banner.primaryLabelEs, banner.primaryLabelEn, t('viewAllReviews'));
+  const primaryHref = resolveHref(banner.primaryLink, locale, `/${locale}/anime-manga`);
+  const secondaryLabel = pickText(banner.secondaryLabelEs, banner.secondaryLabelEn);
+  const secondaryHref = resolveHref(banner.secondaryLink, locale, '#');
+  const backgroundUrl = banner.backgroundUrl?.trim() || null;
+
   return (
     <div>
       {/* ── Hero — warm sumi-sepia card, color only ──────────────────────── */}
       <div className="mb-14 mt-2">
-        <div className="relative overflow-hidden rounded-2xl px-6 sm:px-10 lg:px-16 py-16 sm:py-24 shadow-xl ring-1 ring-persimmon-300/30
-                        bg-[radial-gradient(120%_140%_at_50%_-10%,#5a3a24_0%,#3a2a20_38%,#2a2018_72%,#231a14_100%)]">
+        <div
+          className="relative overflow-hidden rounded-2xl px-6 sm:px-10 lg:px-16 py-16 sm:py-24 shadow-xl ring-1 ring-persimmon-300/30
+                     bg-[radial-gradient(120%_140%_at_50%_-10%,#5a3a24_0%,#3a2a20_38%,#2a2018_72%,#231a14_100%)]"
+          style={
+            backgroundUrl
+              ? {
+                  backgroundImage: `url(${backgroundUrl})`,
+                  backgroundSize: 'cover',
+                  backgroundPosition: 'center',
+                }
+              : undefined
+          }
+        >
+          {/* Dark overlay for legibility when a background image is set */}
+          {backgroundUrl && (
+            <div className="absolute inset-0 bg-[#231a14]/70" aria-hidden="true" />
+          )}
 
           {/* ── Content ── */}
           <div className="relative mx-auto max-w-2xl text-center">
             <span className="gc-kicker text-persimmon-300 block mb-5">
-              {t('heroKicker')}
+              {kicker}
             </span>
             <h1 className="font-display text-4xl sm:text-5xl font-black text-paper-100 leading-tight mb-4 [text-shadow:0_2px_24px_rgba(0,0,0,0.35)]">
-              {t('heroTitle')}
+              {heroTitle}
             </h1>
             <p className="font-body text-ink-300 text-lg leading-relaxed mb-8 max-w-xl mx-auto">
-              {t('subtitle')}
+              {subtitle}
             </p>
-            <Link
-              href={`/${locale}/anime-manga`}
-              className="inline-flex items-center gap-2 bg-persimmon-500 hover:bg-persimmon-600 text-[#FFF8F0] font-ui font-bold px-6 py-3 rounded-pill shadow-md transition-colors active:translate-y-px"
-            >
-              {t('viewAllReviews')}
-              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-              </svg>
-            </Link>
+            <div className="flex flex-wrap items-center justify-center gap-3">
+              {isExternal(banner.primaryLink) ? (
+                <a
+                  href={primaryHref}
+                  className="inline-flex items-center gap-2 bg-persimmon-500 hover:bg-persimmon-600 text-[#FFF8F0] font-ui font-bold px-6 py-3 rounded-pill shadow-md transition-colors active:translate-y-px"
+                >
+                  {primaryLabel}
+                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+                  </svg>
+                </a>
+              ) : (
+                <Link
+                  href={primaryHref}
+                  className="inline-flex items-center gap-2 bg-persimmon-500 hover:bg-persimmon-600 text-[#FFF8F0] font-ui font-bold px-6 py-3 rounded-pill shadow-md transition-colors active:translate-y-px"
+                >
+                  {primaryLabel}
+                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+                  </svg>
+                </Link>
+              )}
+
+              {secondaryLabel && (
+                isExternal(banner.secondaryLink) ? (
+                  <a
+                    href={secondaryHref}
+                    className="inline-flex items-center gap-2 bg-paper-100/10 hover:bg-paper-100/20 text-paper-100 ring-1 ring-paper-100/30 font-ui font-bold px-6 py-3 rounded-pill transition-colors active:translate-y-px"
+                  >
+                    {secondaryLabel}
+                  </a>
+                ) : (
+                  <Link
+                    href={secondaryHref}
+                    className="inline-flex items-center gap-2 bg-paper-100/10 hover:bg-paper-100/20 text-paper-100 ring-1 ring-paper-100/30 font-ui font-bold px-6 py-3 rounded-pill transition-colors active:translate-y-px"
+                  >
+                    {secondaryLabel}
+                  </Link>
+                )
+              )}
+            </div>
           </div>
         </div>
       </div>

--- a/src/app/api/home-banner/image/route.ts
+++ b/src/app/api/home-banner/image/route.ts
@@ -1,0 +1,64 @@
+import { NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+
+const BANNER_ID = 'home';
+
+const ALLOWED_IMAGE_HOSTS = [
+  'example.com',
+  'images.unsplash.com',
+  'via.placeholder.com',
+  'picsum.photos',
+  'imgsrv.crunchyroll.com',
+  'images3.alphacoders.com',
+  'i.imgur.com',
+  'cdn.myanimelist.net',
+];
+
+function isAllowedImageUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol !== 'https:') return false;
+    return ALLOWED_IMAGE_HOSTS.some(
+      (host) => parsed.hostname === host || parsed.hostname.endsWith('.' + host)
+    );
+  } catch {
+    return false;
+  }
+}
+
+// GET the banner background image. Serves an uploaded image from the
+// database, or redirects to an allow-listed external URL.
+export async function GET() {
+  try {
+    const banner = await prisma.homeBanner.findUnique({
+      where: { id: BANNER_ID },
+      select: { imageData: true, imageMimeType: true, backgroundImage: true },
+    });
+
+    if (!banner) {
+      return NextResponse.json({ error: 'No banner found' }, { status: 404 });
+    }
+
+    if (banner.imageData && banner.imageMimeType) {
+      const imageBuffer = Buffer.from(banner.imageData, 'base64');
+      return new NextResponse(imageBuffer, {
+        headers: {
+          'Content-Type': banner.imageMimeType,
+          'Cache-Control': 'public, max-age=3600, must-revalidate',
+        },
+      });
+    }
+
+    if (banner.backgroundImage) {
+      if (!isAllowedImageUrl(banner.backgroundImage)) {
+        return NextResponse.json({ error: 'Image URL not permitted' }, { status: 403 });
+      }
+      return NextResponse.redirect(banner.backgroundImage);
+    }
+
+    return NextResponse.json({ error: 'No background image set' }, { status: 404 });
+  } catch (error) {
+    console.error('Error serving banner image:', error);
+    return NextResponse.json({ error: 'Failed to serve image' }, { status: 500 });
+  }
+}

--- a/src/app/api/home-banner/route.ts
+++ b/src/app/api/home-banner/route.ts
@@ -1,0 +1,101 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '../auth/[...nextauth]/authOptions';
+import { homeBannerSchema, validateInput } from '@/lib/validation';
+import { z } from 'zod';
+import { csrfMiddleware } from '@/lib/csrf';
+import { rateLimitMiddleware } from '@/lib/rateLimit';
+import { prisma } from '@/lib/prisma';
+import { logger } from '@/lib/logger';
+
+const BANNER_ID = 'home';
+
+// GET the full banner record (admin only — includes raw imageData so the
+// editor can show a preview of an uploaded background).
+export async function GET(request: NextRequest) {
+  try {
+    const rateLimitResult = await rateLimitMiddleware(request);
+    if (rateLimitResult) {
+      return rateLimitResult;
+    }
+
+    const session = await getServerSession(authOptions);
+    if (!session?.user?.email) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+    if (session.user.role !== 'admin') {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+    }
+
+    const banner = await prisma.homeBanner.findUnique({ where: { id: BANNER_ID } });
+    return NextResponse.json(banner ?? {});
+  } catch (error) {
+    logger.error('Error fetching home banner', error as Error);
+    return NextResponse.json({ error: 'Failed to fetch home banner' }, { status: 500 });
+  }
+}
+
+// PUT (upsert) the banner record (admin only).
+export async function PUT(request: NextRequest) {
+  let session;
+  try {
+    const rateLimitResult = await rateLimitMiddleware(request);
+    if (rateLimitResult) {
+      return rateLimitResult;
+    }
+
+    if (process.env.NODE_ENV === 'production') {
+      const csrfResult = await csrfMiddleware(request);
+      if (csrfResult) {
+        return csrfResult;
+      }
+    }
+
+    session = await getServerSession(authOptions);
+    if (!session?.user?.email) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+    if (session.user.role !== 'admin') {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+    }
+
+    const body = await request.json();
+    const validationResult = validateInput(homeBannerSchema, body);
+    if (!validationResult.success) {
+      return NextResponse.json({ error: validationResult.error }, { status: 400 });
+    }
+
+    const data = validationResult.data as z.infer<typeof homeBannerSchema>;
+
+    // Normalise undefined → null so cleared fields are actually wiped.
+    const values = {
+      kickerEs: data.kickerEs ?? null,
+      kickerEn: data.kickerEn ?? null,
+      titleEs: data.titleEs ?? null,
+      titleEn: data.titleEn ?? null,
+      subtitleEs: data.subtitleEs ?? null,
+      subtitleEn: data.subtitleEn ?? null,
+      primaryLabelEs: data.primaryLabelEs ?? null,
+      primaryLabelEn: data.primaryLabelEn ?? null,
+      primaryLink: data.primaryLink ?? null,
+      secondaryLabelEs: data.secondaryLabelEs ?? null,
+      secondaryLabelEn: data.secondaryLabelEn ?? null,
+      secondaryLink: data.secondaryLink ?? null,
+      backgroundImage: data.backgroundImage ?? null,
+      imageData: data.imageData ?? null,
+      imageMimeType: data.imageMimeType ?? null,
+    };
+
+    const banner = await prisma.homeBanner.upsert({
+      where: { id: BANNER_ID },
+      update: values,
+      create: { id: BANNER_ID, ...values },
+    });
+
+    logger.info('Home banner updated', { email: session.user.email });
+    return NextResponse.json(banner);
+  } catch (error) {
+    logger.error('Error updating home banner', error as Error, { userEmail: session?.user?.email });
+    return NextResponse.json({ error: 'Failed to update home banner' }, { status: 500 });
+  }
+}

--- a/src/app/api/public/home-banner/route.ts
+++ b/src/app/api/public/home-banner/route.ts
@@ -1,0 +1,44 @@
+import { NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+
+const BANNER_ID = 'home';
+
+// Public, read-only view of the homepage banner. Text fields are returned
+// as-is (the homepage picks the language and falls back to translated
+// defaults for any empty field). The background, if any, is exposed as a
+// single URL so the homepage can render it as a CSS background.
+export async function GET() {
+  try {
+    const banner = await prisma.homeBanner.findUnique({ where: { id: BANNER_ID } });
+
+    if (!banner) {
+      return NextResponse.json({ backgroundUrl: null });
+    }
+
+    const hasUpload = Boolean(banner.imageData && banner.imageMimeType);
+    const backgroundUrl = hasUpload
+      // Cache-bust on update so a newly uploaded image shows immediately.
+      ? `/api/home-banner/image?v=${new Date(banner.updatedAt).getTime()}`
+      : banner.backgroundImage || null;
+
+    return NextResponse.json({
+      kickerEs: banner.kickerEs,
+      kickerEn: banner.kickerEn,
+      titleEs: banner.titleEs,
+      titleEn: banner.titleEn,
+      subtitleEs: banner.subtitleEs,
+      subtitleEn: banner.subtitleEn,
+      primaryLabelEs: banner.primaryLabelEs,
+      primaryLabelEn: banner.primaryLabelEn,
+      primaryLink: banner.primaryLink,
+      secondaryLabelEs: banner.secondaryLabelEs,
+      secondaryLabelEn: banner.secondaryLabelEn,
+      secondaryLink: banner.secondaryLink,
+      backgroundUrl,
+    });
+  } catch (error) {
+    console.error('Error fetching public home banner:', error);
+    // Fail soft — the homepage will just use its translated defaults.
+    return NextResponse.json({ backgroundUrl: null });
+  }
+}

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -61,6 +61,39 @@ export const reviewSchema = z.object({
   status: z.enum(['draft', 'published', 'archived']).default('draft'),
 });
 
+// Home banner validation schema.
+// All fields are optional — an empty banner simply falls back to the
+// translated defaults on the homepage. Links may be internal paths
+// (e.g. "anime-manga", "/anime-manga") or absolute http(s) URLs.
+const optionalLink = z.preprocess(
+  (val) => (val === '' ? null : val),
+  z.string().max(500).optional().nullable()
+);
+
+export const homeBannerSchema = z.object({
+  kickerEs: optionalText(1, 120),
+  kickerEn: optionalText(1, 120),
+  titleEs: optionalText(1, 200),
+  titleEn: optionalText(1, 200),
+  subtitleEs: optionalText(1, 400),
+  subtitleEn: optionalText(1, 400),
+  primaryLabelEs: optionalText(1, 80),
+  primaryLabelEn: optionalText(1, 80),
+  primaryLink: optionalLink,
+  secondaryLabelEs: optionalText(1, 80),
+  secondaryLabelEn: optionalText(1, 80),
+  secondaryLink: optionalLink,
+  backgroundImage: optionalUrl,
+  imageData: z.preprocess(
+    (val) => (val === '' ? null : val),
+    z.string().regex(BASE64_RE, { message: 'imageData must be valid base64' }).optional().nullable()
+  ),
+  imageMimeType: z.preprocess(
+    (val) => (val === '' ? null : val),
+    z.enum(ALLOWED_IMAGE_MIME_TYPES).optional().nullable()
+  ),
+});
+
 // User validation schema
 export const userSchema = z.object({
   name: z.string().min(2).max(50).optional(),


### PR DESCRIPTION
## Summary

Two homepage improvements:

### 1. Hide empty sections and redundant filters
- **Homepage:** the Anime and Manga sections (and the divider between them) only render when they actually contain reviews. Skeletons still show while loading.
- **Anime & Manga page:** the All/Anime/Manga filter buttons only appear when *both* categories have reviews, since filtering is pointless otherwise.

### 2. New admin section: Home Banner
A new **Home Banner** item in the admin sidebar (`/admin/banner`) lets you customise the homepage hero without code changes:

- **Text** (bilingual ES/EN): kicker, title, subtitle
- **Primary button**: label (per language) + link
- **Secondary button** (optional): label + link — hidden on the site if the label is empty
- **Background image** (optional): upload a file or paste a URL, with a live preview. Empty keeps the existing gradient.

Links accept an internal path (e.g. `anime-manga`, shown in the visitor's language automatically) or a full `http(s)://` URL.

**Backward compatible:** every field falls back to the current i18n defaults, so the homepage is unchanged until a banner is saved. Image uploads reuse the existing `/api/upload` WebP pipeline.

## How it works

| Piece | File |
|---|---|
| `HomeBanner` singleton model (id `"home"`) | `prisma/schema.prisma` |
| Admin read/write (auth + CSRF) | `src/app/api/home-banner/route.ts` |
| Public read for homepage | `src/app/api/public/home-banner/route.ts` |
| Background image serving (DB upload or allow-listed URL) | `src/app/api/home-banner/image/route.ts` |
| Validation schema | `src/lib/validation.ts` |
| Editor UI + sidebar link | `src/app/[locale]/admin/banner/page.tsx`, `admin/layout.tsx` |
| Homepage consumes the banner | `src/app/[locale]/page.tsx` |

## Deploy note
The `HomeBanner` table is created by `prisma db push`, which already runs in the `build` script, so the schema change applies automatically on deploy.

## Verification
- Regenerated the Prisma client and ran `tsc --noEmit` — all of `src/` is type-clean.
- ESLint/`next build` couldn't complete due to a pre-existing config issue (`eslint.config.mjs` references `next/typescript`, not provided by the pinned `eslint-config-next@14.1.2`) — unrelated to these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QEqyrbxatWCjMMGTWyjcZ4)_