### PR TITLE
Force home banner API routes to run dynamically

### DIFF
--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -104,7 +104,7 @@ export default function Home() {
         const [animeRes, mangaRes, bannerRes] = await Promise.all([
           fetch('/api/public/reviews?category=anime&limit=12'),
           fetch('/api/public/reviews?category=manga&limit=12'),
-          fetch('/api/public/home-banner'),
+          fetch('/api/public/home-banner', { cache: 'no-store' }),
         ]);
         setAnimeReviews(animeRes.ok ? await animeRes.json() : []);
         setMangaReviews(mangaRes.ok ? await mangaRes.json() : []);

--- a/src/app/api/home-banner/image/route.ts
+++ b/src/app/api/home-banner/image/route.ts
@@ -26,6 +26,9 @@ function isAllowedImageUrl(url: string): boolean {
   }
 }
 
+// Serve the current image on every request rather than caching at build time.
+export const dynamic = 'force-dynamic';
+
 // GET the banner background image. Serves an uploaded image from the
 // database, or redirects to an allow-listed external URL.
 export async function GET() {

--- a/src/app/api/public/home-banner/route.ts
+++ b/src/app/api/public/home-banner/route.ts
@@ -3,6 +3,11 @@ import { prisma } from '@/lib/prisma';
 
 const BANNER_ID = 'home';
 
+// This handler has no request-derived inputs, so Next.js would otherwise
+// cache it as a static route at build time and keep serving a stale (empty)
+// banner. Force it to run on every request so edits show up immediately.
+export const dynamic = 'force-dynamic';
+
 // Public, read-only view of the homepage banner. Text fields are returned
 // as-is (the homepage picks the language and falls back to translated
 // defaults for any empty field). The background, if any, is exposed as a


### PR DESCRIPTION
The public banner and banner-image GET handlers have no request-derived inputs, so Next.js cached them as static routes at build time and kept serving the stale (empty) banner even after edits were saved. Mark both as force-dynamic and fetch the banner with no-store on the homepage so changes appear immediately.


Claude-Session: https://claude.ai/code/session_01QEqyrbxatWCjMMGTWyjcZ4